### PR TITLE
Add Address Parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*.egg-info
+.pytest_cache
+__pycache__

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,10 @@
         "xxhash"
     ],
     "python.formatting.provider": "yapf",
+    "python.formatting.yapfArgs": [
+        "--style",
+        "${workspaceRoot}/setup.cfg"
+    ],
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
     "python.pythonPath": "C:\\Users\\gbunce\\AppData\\Local\\Programs\\ArcGIS\\Pro\\bin\\Python\\envs\\sweeper\\python.exe"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "conda",
         "objectid",
         "posix",
+        "usaddress",
         "xxhash"
     ],
     "python.formatting.provider": "yapf",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,10 @@
 {
     "cSpell.words": [
+        "ALVEY",
         "AVEN",
+        "DALY",
+        "MCDANIEL",
+        "SEGO",
         "conda",
         "objectid",
         "pformat",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "AVEN",
         "conda",
         "objectid",
         "pformat",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
     "cSpell.words": [
         "conda",
         "objectid",
+        "pformat",
         "posix",
         "usaddress",
         "xxhash"

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,13 @@ A normalized string representing the entire address that was passed into the con
    - `conda create --clone arcgispro-py3 --name sweeper`
 1. activate environment
    - `activate sweeper`
-1. install dependencies
-   - `conda install -y -f --file requirements.dev.txt`
+
+### Installing dependencies
+
+1. install only required dependencies to run sweeper
+   - `pip install -e .`
+1. install required dependencies to work on sweeper
+   - `pip install -e ".[develop]"`
+1. install required dependencies to run sweeper tests
+   - `pip install -e ".[test]"`
 1. run tests: `pytest`

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,55 @@
 
 fix data
 
+## Parsing Addresses
+
+This project contains a module that can be used as a standalone address parser, `sweeper.address_parser`. This allows developer to take advantage of sweepers advanced address parsing and normalization without having to run the entire sweeper process.
+
+### Usage Example
+
+```python
+from sweeper.address_parser import Address
+
+address = Address('123 South Main Street')
+print(address)
+
+'''
+--> Parsed Address:
+{'address_number': '123',
+ 'normalized': '123 S MAIN ST',
+ 'prefix_direction': 'S',
+ 'street_name': 'MAIN',
+ 'street_type': 'ST'}
+'''
+```
+
+### Available Address class properties
+
+All properties default to None if there is no parsed value.
+
+`address_number`
+
+`address_number_suffix`
+
+`prefix_direction`
+
+`street_name`
+
+`street_direction`
+
+`street_type`
+
+`unit_type`
+
+`unit_id`
+
+`city`
+
+`zip_code`
+
+`normalized`
+A normalized string representing the entire address that was passed into the constructor.
+
 ## development
 
 1. create conda environment

--- a/readme.md
+++ b/readme.md
@@ -49,8 +49,11 @@ If no `unit_type` is found, this property is prefixed with `#` (e.g. `# 3`). If 
 
 `zip_code`
 
+`po_box`
+The PO Box if a po-box-type address was entered (e.g. `po_box` would be `1` for `p.o. box 1`).
+
 `normalized`
-A normalized string representing the entire address that was passed into the constructor.
+A normalized string representing the entire address that was passed into the constructor. PO Boxes are normalized in this format `PO BOX <number>`.
 
 ## development
 

--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ All properties default to None if there is no parsed value.
 `unit_type`
 
 `unit_id`
+If no `unit_type` is found, this property is prefixed with `#` (e.g. `# 3`). If `unit_type` is found, `#` is stripped from this property.
 
 `city`
 

--- a/readme.md
+++ b/readme.md
@@ -9,6 +9,5 @@ fix data
 1. activate environment
    - `activate sweeper`
 1. install dependencies
-   - `pip install -r requirements.txt`
-1. install dev dependencies
-   - `pip installal -r requirements.dev.txt`
+   - `conda install -y -f --file requirements.dev.txt`
+1. run tests: `pytest`

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -2,3 +2,4 @@
 
 yapf
 pylint
+pytest

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,5 +1,0 @@
--r ./requirements.txt
-
-yapf
-pylint
-pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-docopt
-fiona
-geopandas
-xxhash
-usaddress

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ docopt
 fiona
 geopandas
 xxhash
-
+usaddress

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[style]
+[yapf]
 based_on_style=google
 ALLOW_SPLIT_BEFORE_DICT_VALUE=False
 COLUMN_LIMIT=160
@@ -7,3 +7,10 @@ DEDENT_CLOSING_BRACKETS=True
 EACH_DICT_ENTRY_ON_SEPARATE_LINE=True
 INDENT_DICTIONARY_VALUE=False
 SPLIT_BEFORE_DOT=True
+[tool:pytest]
+minversion = 3.5
+console_output_style = count
+pep8maxlinelength = 160
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -38,10 +38,19 @@ setup(
     keywords=[],
     install_requires=[
         'docopt==0.6.*',
+        'fiona',
+        'geopandas',
+        'xxhash',
+        'usaddress'
     ],
     dependency_links=[],
     extras_require={
         'tests': [
+            'pytest',
+        ],
+        'develop': [
+            'yapf',
+            'pylint'
         ]
     },
     entry_points={"console_scripts": ["sweeper = sweeper.sweeper:__main__"]}

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -34,6 +34,7 @@ TAG_MAPPING = {
     # 'StateName': 'state',
     'ZipCode': 'zip_code',
 }
+TWO_CHAR_DIRECTIONS = ['NO', 'SO', 'EA', 'WE']
 
 
 class Address():
@@ -66,6 +67,11 @@ class Address():
             except AttributeError:
                 pass
 
+        #: look for two-character prefix directions which usaddress does not handle
+        street_name_parts = self.street_name.split(' ')
+        if len(street_name_parts) > 1 and street_name_parts[0].upper() in TWO_CHAR_DIRECTIONS and self.prefix_direction is None:
+            self.prefix_direction = normalize_direction(street_name_parts[0])
+            self.street_name = ' '.join(street_name_parts[1:])
 
     def __repr__(self):
         return f'Parsed Address:\n{pprint.pformat(vars(self))}'

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -82,7 +82,10 @@ class Address():
             self.street_type = normalize_street_type(self.street_type)
 
     def __repr__(self):
-        return f'Parsed Address:\n{pprint.pformat(vars(self))}'
+        properties = vars(self)
+        properties.update({'normalized': self.normalized})
+
+        return f'Parsed Address:\n{pprint.pformat(properties)}'
 
     @property
     def normalized(self):

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -35,7 +35,8 @@ TAG_MAPPING = {
     # 'SubaddressType': 'address2',
     'PlaceName': 'city',
     # 'StateName': 'state',
-    'ZipCode': 'zip_code'
+    'ZipCode': 'zip_code',
+    'USPSBoxID': 'po_box'
 }
 TWO_CHAR_DIRECTIONS = ['NO', 'SO', 'EA', 'WE']
 with open(join(dirname(realpath(__file__)), 'street_types.json'), 'r') as file:
@@ -56,11 +57,12 @@ class Address():
     unit_id = None
     city = None
     zip_code = None
+    po_box = None
 
     def __init__(self, address_text):
         parts, parsed_as = usaddress.tag(address_text.replace('.', ''), TAG_MAPPING)
-        if parsed_as != 'Street Address':
-            raise Exception(f'{address_text} is not recognized as a valid street address')
+        if parsed_as not in ['Street Address', 'PO Box']:
+            raise Exception(f'{address_text} is not recognized as a valid street address, or P.O. Box')
 
         for part in parts:
             try:
@@ -71,6 +73,9 @@ class Address():
                 setattr(self, part, value)
             except AttributeError:
                 pass
+
+        if self.po_box is not None:
+            return
 
         #: look for two-character prefix directions which usaddress does not handle
         street_name_parts = self.street_name.split(' ')
@@ -101,6 +106,9 @@ class Address():
         '''
         getter for normalized address string
         '''
+        if self.po_box is not None:
+            return f'PO BOX {self.po_box}'
+
         parts = [
             self.address_number,
             self.address_number_suffix,

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# * coding: utf8 *
+'''
+address_parser.py
+A module that parses street addresses into their various parts.
+'''
+import usaddress
+
+
+TAG_MAPPING = {
+    'AddressNumber': 'address_number',
+    # 'AddressNumberPrefix': 'address1',
+    'AddressNumberSuffix': 'address_number_suffix',
+    'StreetNamePreDirectional': 'prefix_direction',
+    'StreetName': 'street_name',
+    # 'StreetNamePreModifier': 'address1',
+    # 'StreetNamePreType': 'address1',
+    'StreetNamePostDirectional': 'suffix_direction',
+    # 'StreetNamePostModifier': 'address1',
+    'StreetNamePostType': 'street_type',
+    # 'CornerOf': 'address1',
+    # 'IntersectionSeparator': 'address1',
+    # 'LandmarkName': 'address1',
+    # 'USPSBoxGroupID': 'address1',
+    # 'USPSBoxGroupType': 'address1',
+    # 'USPSBoxID': 'address1',
+    # 'USPSBoxType': 'address1',
+    # 'BuildingName': 'address2',
+    'OccupancyType': 'unit_type',
+    'OccupancyIdentifier': 'unit_id',
+    # 'SubaddressIdentifier': 'address2',
+    # 'SubaddressType': 'address2',
+    'PlaceName': 'city',
+    # 'StateName': 'state',
+    'ZipCode': 'zip_code',
+}
+
+
+class Address():
+    '''
+    Class for parsing address strings
+    '''
+    address_number = None
+    address_number_suffix = None
+    prefix_direction = None
+    street_name = None
+    street_suffix = None
+    street_type = None
+    unit_type = None
+    unit_id = None
+    city = None
+    zip_code = None
+    def __init__(self, address_text):
+        parts, parsed_as = usaddress.tag(address_text, TAG_MAPPING)
+        if parsed_as != 'Street Address':
+            raise Exception(f'{address_text} is not recognized as a valid street address')
+
+        for part in parts:
+            try:
+                value = parts[part].upper()
+                if part.endswith('direction'):
+                    value = normalize_direction(value)
+
+                setattr(self, part, value)
+            except AttributeError:
+                pass
+
+
+def normalize_direction(direction_text):
+    return direction_text[0].upper()

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -4,8 +4,8 @@
 address_parser.py
 A module that parses street addresses into their various parts.
 '''
+import pprint
 import usaddress
-
 
 TAG_MAPPING = {
     'AddressNumber': 'address_number',
@@ -64,6 +64,10 @@ class Address():
                 setattr(self, part, value)
             except AttributeError:
                 pass
+
+
+    def __repr__(self):
+        return f'Parsed Address:\n{pprint.pformat(vars(self))}'
 
 
 def normalize_direction(direction_text):

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -35,7 +35,7 @@ TAG_MAPPING = {
     # 'SubaddressType': 'address2',
     'PlaceName': 'city',
     # 'StateName': 'state',
-    'ZipCode': 'zip_code',
+    'ZipCode': 'zip_code'
 }
 TWO_CHAR_DIRECTIONS = ['NO', 'SO', 'EA', 'WE']
 with open(join(dirname(realpath(__file__)), 'street_types.json'), 'r') as file:
@@ -80,6 +80,15 @@ class Address():
 
         if self.street_type is not None:
             self.street_type = normalize_street_type(self.street_type)
+
+        if self.unit_id is not None:
+            #: add `#` if there is not unit type
+            if not self.unit_id.startswith('#') and self.unit_type is None:
+                self.unit_id = f'# {self.unit_id}'
+
+            #: strip `#` if there is a unit type
+            elif self.unit_id.startswith('#') and self.unit_type is not None:
+                self.unit_id = self.unit_id[1:].strip()
 
     def __repr__(self):
         properties = vars(self)

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -58,7 +58,7 @@ class Address():
     zip_code = None
 
     def __init__(self, address_text):
-        parts, parsed_as = usaddress.tag(address_text, TAG_MAPPING)
+        parts, parsed_as = usaddress.tag(address_text.replace('.', ''), TAG_MAPPING)
         if parsed_as != 'Street Address':
             raise Exception(f'{address_text} is not recognized as a valid street address')
 

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -76,6 +76,23 @@ class Address():
     def __repr__(self):
         return f'Parsed Address:\n{pprint.pformat(vars(self))}'
 
+    @property
+    def normalized(self):
+        '''
+        getter for normalized address string
+        '''
+        parts = [
+            self.address_number,
+            self.address_number_suffix,
+            self.prefix_direction,
+            self.street_name,
+            self.street_type,
+            self.unit_type,
+            self.unit_id
+        ]
+
+        return ' '.join([part for part in parts if part is not None])
+
 
 def normalize_direction(direction_text):
     return direction_text[0].upper()

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -79,9 +79,13 @@ class Address():
 
         #: look for two-character prefix directions which usaddress does not handle
         street_name_parts = self.street_name.split(' ')
-        if len(street_name_parts) > 1 and street_name_parts[0].upper() in TWO_CHAR_DIRECTIONS and self.prefix_direction is None:
-            self.prefix_direction = normalize_direction(street_name_parts[0])
-            self.street_name = ' '.join(street_name_parts[1:])
+        if len(street_name_parts) > 1:
+            if street_name_parts[0].upper() in TWO_CHAR_DIRECTIONS and self.prefix_direction is None:
+                self.prefix_direction = normalize_direction(street_name_parts[0])
+                self.street_name = ' '.join(street_name_parts[1:])
+            elif street_name_parts[-1].upper() in TWO_CHAR_DIRECTIONS and self.street_direction is None:
+                self.street_direction = normalize_direction(street_name_parts[-1])
+                self.street_name = ' '.join(street_name_parts[:-1])
 
         if self.street_type is not None:
             self.street_type = normalize_street_type(self.street_type)

--- a/src/sweeper/address_parser.py
+++ b/src/sweeper/address_parser.py
@@ -15,7 +15,7 @@ TAG_MAPPING = {
     'StreetName': 'street_name',
     # 'StreetNamePreModifier': 'address1',
     # 'StreetNamePreType': 'address1',
-    'StreetNamePostDirectional': 'suffix_direction',
+    'StreetNamePostDirectional': 'street_direction',
     # 'StreetNamePostModifier': 'address1',
     'StreetNamePostType': 'street_type',
     # 'CornerOf': 'address1',
@@ -44,12 +44,13 @@ class Address():
     address_number_suffix = None
     prefix_direction = None
     street_name = None
-    street_suffix = None
+    street_direction = None
     street_type = None
     unit_type = None
     unit_id = None
     city = None
     zip_code = None
+
     def __init__(self, address_text):
         parts, parsed_as = usaddress.tag(address_text, TAG_MAPPING)
         if parsed_as != 'Street Address':

--- a/src/sweeper/street_types.json
+++ b/src/sweeper/street_types.json
@@ -1,0 +1,320 @@
+{
+    "ALY": [
+        "ALLEE",
+        "ALLEY",
+        "ALLY",
+        "ALY"
+    ],
+    "AVE": [
+        "AV",
+        "AVE",
+        "AVEN",
+        "AVENU",
+        "AVENUE",
+        "AVN",
+        "AVNUE"
+    ],
+    "BAY": [],
+    "BLVD": [
+        "BLVD",
+        "BOUL",
+        "BOULEVARD",
+        "BOULV"
+    ],
+    "BND": [
+        "BEND",
+        "BND"
+    ],
+    "CIR": [
+        "CIR",
+        "CIRC",
+        "CIRCL",
+        "CIRCLE",
+        "CRCL",
+        "CRCLE"
+    ],
+    "COR": [
+        "COR",
+        "CORNER"
+    ],
+    "CRES": [
+        "CRECENT",
+        "CRES",
+        "CRESCENT",
+        "CRESENT",
+        "CRSCNT",
+        "CRSENT",
+        "CRSNT"
+    ],
+    "CRK": [
+        "CK",
+        "CR",
+        "CREEK",
+        "CRK"
+    ],
+    "CT": [
+        "COURT",
+        "CRT",
+        "CT"
+    ],
+    "CTR": [
+        "CEN",
+        "CENT",
+        "CENTER",
+        "CENTR",
+        "CENTRE",
+        "CNTER",
+        "CNTR",
+        "CTR"
+    ],
+    "CV": [
+        "COVE",
+        "CV"
+    ],
+    "CYN": [
+        "CANYN",
+        "CANYON",
+        "CNYN",
+        "CYN"
+    ],
+    "DR": [
+        "DRIV",
+        "DRIVE",
+        "DRV",
+        "DR"
+    ],
+    "EST": [
+        "EST",
+        "ESTATE"
+    ],
+    "ESTS": [
+        "ESTATES",
+        "ESTS"
+    ],
+    "EXPY": [
+        "EXP",
+        "EXPR",
+        "EXPRESS",
+        "EXPRESSWAY",
+        "EXPW",
+        "EXPY"
+    ],
+    "FLT": [
+        "FLAT",
+        "FLT"
+    ],
+    "FRK": [
+        "FORK",
+        "FRK"
+    ],
+    "FWY": [
+        "FREEWAY",
+        "FREEWY",
+        "FRWAY",
+        "FRWY",
+        "FWY"
+    ],
+    "GLN": [
+        "GLEN",
+        "GLN"
+    ],
+    "GRV": [
+        "GROV",
+        "GROVE",
+        "GRV"
+    ],
+    "GTWY": [
+        "GATEWAY",
+        "GATEWY",
+        "GATWAY",
+        "GTWAY",
+        "GTWY"
+    ],
+    "HL": [
+        "HILL",
+        "HL"
+    ],
+    "HOLW": [
+        "HLLW",
+        "HOLLOW",
+        "HOLLOWS",
+        "HOLW",
+        "HOLWS"
+    ],
+    "HTS": [
+        "HEIGHT",
+        "HEIGHTS",
+        "HGTS",
+        "HT",
+        "HTS"
+    ],
+    "HWY": [
+        "HIGHWAY",
+        "HIGHWY",
+        "HIWAY",
+        "HIWY",
+        "HWAY",
+        "HWY"
+    ],
+    "JCT": [
+        "JCT",
+        "JCTION",
+        "JCTN",
+        "JUNCTION",
+        "JUNCTN",
+        "JUNCTON"
+    ],
+    "LN": [
+        "LA",
+        "LANE",
+        "LANES",
+        "LN"
+    ],
+    "LNDG": [
+        "LANDING",
+        "LNDG",
+        "LNDNG"
+    ],
+    "LOOP": [
+        "LOOP",
+        "LOOPS"
+    ],
+    "MDW": [
+        "MDW",
+        "MEADOW"
+    ],
+    "MDWS": [
+        "MDWS",
+        "MEADOWS",
+        "MEDOWS"
+    ],
+    "MNR": [
+        "MANOR",
+        "MNR"
+    ],
+    "PARK": [
+        "PARK",
+        "PK",
+        "PRK",
+        "PARKS"
+    ],
+    "PASS": [
+        "PASS"
+    ],
+    "PATH": [
+        "PATH",
+        "PATHS"
+    ],
+    "PKWY": [
+        "PARKWAY",
+        "PARKWY",
+        "PKWAY",
+        "PKWY",
+        "PKY",
+        "PARKWAYS",
+        "PKWYS"
+    ],
+    "PL": [
+        "PL",
+        "PLACE"
+    ],
+    "PLZ": [
+        "PLAZA",
+        "PLZA",
+        "PLZ"
+    ],
+    "PT": [
+        "POINT",
+        "PT"
+    ],
+    "RAMP": [
+        "RAMP"
+    ],
+    "RD": [
+        "RD",
+        "ROAD"
+    ],
+    "RDG": [
+        "RDG",
+        "RDGE",
+        "RIDGE"
+    ],
+    "RNCH": [
+        "RANCH",
+        "RANCHES",
+        "RNCH",
+        "RNCHS"
+    ],
+    "ROW": [
+        "ROW"
+    ],
+    "RTE": [
+        "ROUTE"
+    ],
+    "RUN": [
+        "RUN"
+    ],
+    "SPUR": [
+        "SPUR",
+        "SPURS"
+    ],
+    "SQ": [
+        "SQ",
+        "SQR",
+        "SQRE",
+        "SQUARE",
+        "SQU"
+    ],
+    "ST": [
+        "ST",
+        "STRT",
+        "STR",
+        "STREET"
+    ],
+    "TER": [
+        "TER",
+        "TERR",
+        "TERRACE"
+    ],
+    "TRCE": [
+        "TRACE",
+        "TRACES",
+        "TRCE"
+    ],
+    "TRL": [
+        "TR",
+        "TRAILS",
+        "TRL",
+        "TRLS",
+        "TRAIL"
+    ],
+    "VIS": [
+        "VIST",
+        "VISTA",
+        "VSTA",
+        "VIS",
+        "VST"
+    ],
+    "VLG": [
+        "VILL",
+        "VILLAGE",
+        "VILLG",
+        "VILLIAGE",
+        "VLG",
+        "VILLAG"
+    ],
+    "VW": [
+        "VIEW",
+        "VW"
+    ],
+    "WAY": [
+        "WAY",
+        "WY"
+    ],
+    "XING": [
+        "CROSSING",
+        "CRSSING",
+        "CRSSNG",
+        "XING"
+    ]
+}

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -14,21 +14,21 @@ class TestAddressNumber():
     tests for parsing address numbers
     '''
     def test_parses_address_number(self):
-    tests = [
-        ['123 main street', '123'],
-        ['4 main street', '4']
-    ]
+        tests = [
+            ['123 main street', '123'],
+            ['4 main street', '4']
+        ]
 
-    for input_text, expected in tests:
-        assert Address(input_text).address_number == expected
+        for input_text, expected in tests:
+            assert Address(input_text).address_number == expected
 
 
 class TestAddressNumberSuffix():
     '''
     tests for parsing address number suffixes
     '''
-    def test_parses_address_number_suffix(self):
-    tests = [
+    def test_parses_number_suffix(self):
+        tests = [
             ['123 1/2 s main street', '1/2']
         ]
 
@@ -43,13 +43,13 @@ class TestPrefixDirection():
     def test_parses_prefix_direction(self):
         tests = [
             ['123 1/2 S main street', 'S'],
-        ['123 S main street', 'S'],
+            ['123 S main street', 'S'],
             ['456 North main', 'N'],
             ['123 EA Some Street', 'E']
-    ]
+        ]
 
-    for input_text, expected in tests:
-        assert Address(input_text).prefix_direction == expected
+        for input_text, expected in tests:
+            assert Address(input_text).prefix_direction == expected
 
 
 class TestStreetName():
@@ -57,20 +57,20 @@ class TestStreetName():
     tests for parsing street names
     '''
     def test_parses_street_name(self):
-    tests = [
-        ['123 S main street', 'MAIN'],
-        ['456 North main', 'MAIN']
-    ]
+        tests = [
+            ['123 S main street', 'MAIN'],
+            ['456 North main', 'MAIN']
+        ]
 
-    for input_text, expected in tests:
-        assert Address(input_text).street_name == expected
+        for input_text, expected in tests:
+            assert Address(input_text).street_name == expected
 
     def test_multi_word_street_name(self):
         address = Address('123 S Main Hello Street')
 
         assert address.street_name == 'MAIN HELLO'
 
-    def test_no_prefix_direction_street_name(self):
+    def test_no_prefix_direction_street(self):
         address = Address('123 Main Street')
 
         assert address.street_name == 'MAIN'
@@ -93,15 +93,15 @@ class TestNormalizeDirection():
     tests for normalizing cardinal directions
     '''
     def test_normalize_direction(self):
-    north_tests = [
-        'North',
-        'N',
-        'north',
-        'n'
-    ]
+        north_tests = [
+            'North',
+            'N',
+            'north',
+            'n'
+        ]
 
-    for text in north_tests:
-        assert normalize_direction(text) == 'N'
+        for text in north_tests:
+            assert normalize_direction(text) == 'N'
 
     def test_two_characters(self):
         assert normalize_direction('EA') == 'E'
@@ -141,3 +141,186 @@ def test_normalized_address_string():
 
     assert address.normalized == '123 E 400 W'
 
+    # def test_doubleSpaces(self):
+    #     address = Address('  123  ea main  st')
+
+    #     assert address.houseNumber == '123'
+    #     assert address.prefixDirection == 'E'
+    #     assert address.streetName == 'MAIN'
+    #     assert address.suffix_type == 'ST'
+
+    # def test_noPreDir(self):
+    #     address = Address('1901 Sidewinder Dr')
+
+    #     assert address.houseNumber == '1901'
+    #     assert address.prefixDirection == None
+    #     assert address.streetName == 'SIDEWINDER'
+    #     assert address.suffix_type == 'DR'
+    #     assert address.suffix_direction == None
+    #     assert address.normalizedAddressString == '1901 SIDEWINDER DR'
+
+    # def test_stripPeriods(self):
+    #     address = Address('  123 ea main st.')
+
+    #     assert address.houseNumber == '123'
+    #     assert address.prefixDirection == 'E'
+    #     assert address.streetName == 'MAIN'
+    #     assert address.suffix_type == 'ST'
+    #     assert address.suffix_direction == None
+    #     assert address.normalizedAddressString == '123 E MAIN ST'
+
+    # # tests from Steve's geocoder...
+    # def test_steves(self):
+    #     address = Address("5301 w jacob hill cir")
+    #     assert '5301' == address.houseNumber
+    #     assert "JACOB HILL" == address.streetName
+    #     assert 'CIR' == address.suffix_type
+
+    #     address = Address("400 S 532 E")
+    #     assert '400' == address.houseNumber
+    #     assert "532" == address.streetName
+    #     assert 'E' == address.suffix_direction
+
+    #     address = Address("5625 S 995 E")
+    #     assert '5625' == address.houseNumber
+    #     assert "995" == address.streetName
+    #     assert 'E' == address.suffix_direction
+
+    #     address = Address("372 North 600 East")
+    #     assert '372' == address.houseNumber
+    #     assert "600" == address.streetName
+    #     assert 'E' == address.suffix_direction
+
+    #     address = Address("30 WEST 300 NORTH")
+    #     assert '30' == address.houseNumber
+    #     assert "300" == address.streetName
+    #     assert 'N' == address.suffix_direction
+
+    #     address = Address("126 E 400 N")
+    #     assert '126' == address.houseNumber
+    #     assert "400" == address.streetName
+    #     assert 'N' == address.suffix_direction
+
+    #     address = Address("270 South 1300 East")
+    #     assert '270' == address.houseNumber
+    #     assert "1300" == address.streetName
+    #     assert 'E' == address.suffix_direction
+
+    #     address = Address("126 W SEGO LILY DR")
+    #     assert '126' == address.houseNumber
+    #     assert "SEGO LILY" == address.streetName
+    #     assert 'DR' == address.suffix_type
+
+    #     address = Address("261 E MUELLER PARK RD")
+    #     assert '261' == address.houseNumber
+    #     assert "MUELLER PARK" == address.streetName
+    #     assert 'RD' == address.suffix_type
+
+    #     address = Address("17 S VENICE MAIN ST")
+    #     assert '17' == address.houseNumber
+    #     assert "VENICE MAIN" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     address = Address("20 W Center St")
+    #     assert '20' == address.houseNumber
+    #     assert 'W' == address.prefixDirection
+    #     assert "CENTER" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     address = Address("9314 ALVEY LN")
+    #     assert '9314' == address.houseNumber
+    #     assert "ALVEY" == address.streetName
+    #     assert 'LN' == address.suffix_type
+
+    #     address = Address("167 DALY AVE")
+    #     assert '167' == address.houseNumber
+    #     assert "DALY" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1147 MCDANIEL CIR")
+    #     assert '1147' == address.houseNumber
+    #     assert "MCDANIEL" == address.streetName
+    #     assert 'CIR' == address.suffix_type
+
+    #     address = Address("300 Walk St")
+    #     assert '300' == address.houseNumber
+    #     assert "WALK" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     address = Address("5 Cedar Ave")
+    #     assert '5' == address.houseNumber
+    #     assert "CEDAR" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1238 E 1ST Avenue")
+    #     assert '1238' == address.houseNumber
+    #     assert "1ST" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1238 E FIRST Avenue")
+    #     assert '1238' == address.houseNumber
+    #     assert "FIRST" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1238 E 2ND Avenue")
+    #     assert '1238' == address.houseNumber
+    #     assert "2ND" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1238 E 3RD Avenue")
+    #     assert '1238' == address.houseNumber
+    #     assert "3RD" == address.streetName
+    #     assert 'AVE' == address.suffix_type
+
+    #     address = Address("1573 24TH Street")
+    #     assert '1573' == address.houseNumber
+    #     assert "24TH" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     # if you dont' have a street name but you have a prefix direction then the
+    #     # prefix diretion is probably the street name.
+    #     address = Address("168 N ST")
+    #     assert '168' == address.houseNumber
+    #     assert "N" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     address = Address("168 N N ST")
+    #     assert '168' == address.houseNumber
+    #     assert "N" == address.streetName
+    #     assert 'ST' == address.suffix_type
+
+    #     address = Address("478 S WEST FRONTAGE RD")
+    #     assert '478' == address.houseNumber
+    #     assert "WEST FRONTAGE" == address.streetName
+    #     assert 'RD' == address.suffix_type
+
+    #     address = Address("1048 W 1205 N")
+    #     assert '1048' == address.houseNumber
+    #     assert "1205" == address.streetName
+    #     assert None == address.suffix_type
+    #     assert 'N' == address.suffix_direction
+
+    #     address = Address("2139 N 50 W")
+    #     assert '2139' == address.houseNumber
+    #     assert "50" == address.streetName
+    #     assert None == address.suffix_type
+    #     assert 'W' == address.suffix_direction
+
+    # def test_streetTypeNames(self):
+    #     address = Address('123 E PARKWAY AVE')
+
+    #     assert address.houseNumber == '123'
+    #     assert address.prefixDirection == 'E'
+    #     assert address.streetName == 'PARKWAY'
+    #     assert address.suffix_type == 'AVE'
+    #     assert address.suffix_direction == None
+    #     assert address.normalizedAddressString == '123 E PARKWAY AVE'
+
+    #     address = Address('123 E PARKWAY TRAIL AVE')
+
+    #     assert address.houseNumber == '123'
+    #     assert address.prefixDirection == 'E'
+    #     assert address.streetName == 'PARKWAY TRAIL'
+    #     assert address.suffix_type == 'AVE'
+    #     assert address.suffix_direction == None
+    #     assert address.normalizedAddressString == '123 E PARKWAY TRAIL AVE'

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -178,6 +178,28 @@ class TestNormalizeStreetType():
         assert address.normalized == '123 E PARKWAY TRAIL AVE'
 
 
+class TestUnitParts():
+    '''
+    tests for unit_type and unit_id
+    '''
+    def test_add_hash_if_no_type(self):
+        address = Address('123 s main st 3')
+
+        assert address.unit_type is None
+        assert address.unit_id == '# 3'
+
+        address = Address('123 s main st suite 3')
+
+        assert address.unit_type == 'SUITE'
+        assert address.unit_id == '3'
+
+    def test_strip_hash_if_type(self):
+        address = Address('123 s main st suite #3')
+
+        assert address.unit_type == 'SUITE'
+        assert address.unit_id == '3'
+
+
 def test_normalized_address_string():
     address = Address('123 EA Fifer Place ')
 

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -144,30 +144,16 @@ def test_normalized_address_string():
     # def test_doubleSpaces(self):
     #     address = Address('  123  ea main  st')
 
-    #     assert address.houseNumber == '123'
-    #     assert address.prefixDirection == 'E'
-    #     assert address.streetName == 'MAIN'
-    #     assert address.suffix_type == 'ST'
 
-    # def test_noPreDir(self):
-    #     address = Address('1901 Sidewinder Dr')
+def test_strip_periods():
+    address = Address('  123 ea. main st.')
 
-    #     assert address.houseNumber == '1901'
-    #     assert address.prefixDirection == None
-    #     assert address.streetName == 'SIDEWINDER'
-    #     assert address.suffix_type == 'DR'
-    #     assert address.suffix_direction == None
-    #     assert address.normalizedAddressString == '1901 SIDEWINDER DR'
-
-    # def test_stripPeriods(self):
-    #     address = Address('  123 ea main st.')
-
-    #     assert address.houseNumber == '123'
-    #     assert address.prefixDirection == 'E'
-    #     assert address.streetName == 'MAIN'
-    #     assert address.suffix_type == 'ST'
-    #     assert address.suffix_direction == None
-    #     assert address.normalizedAddressString == '123 E MAIN ST'
+    assert address.address_number == '123'
+    assert address.prefix_direction == 'E'
+    assert address.street_name == 'MAIN'
+    assert address.street_type == 'ST'
+    assert address.street_direction is None
+    assert address.normalized == '123 E MAIN ST'
 
     # # tests from Steve's geocoder...
     # def test_steves(self):

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -4,7 +4,9 @@
 test_address_parser.py
 tests for the address parser module
 '''
-from .address_parser import Address, normalize_direction
+import pytest
+
+from .address_parser import Address, normalize_direction, normalize_street_type, InvalidStreetTypeError
 
 
 class TestAddressNumber():
@@ -87,6 +89,9 @@ class TestStreetDirection():
 
 
 class TestNormalizeDirection():
+    '''
+    tests for normalizing cardinal directions
+    '''
     def test_normalize_direction(self):
     north_tests = [
         'North',
@@ -108,9 +113,27 @@ def test_white_space():
     assert address.street_name == 'MAIN'
 
 
-def test_normalizedAddressString():
+class TestNormalizeStreetType():
+    '''
+    tests for normalizing street types
+    '''
+    def test_normalize_street_type(self):
+        tests = [
+            ['ALY', 'ALY'],
+            ['AVEN', 'AVE'],
+            ['corner', 'COR']
+        ]
+
+        for input_text, expected in tests:
+            assert normalize_street_type(input_text) == expected
+
+    def test_raises_exceptions(self):
+        with pytest.raises(InvalidStreetTypeError):
+            normalize_street_type('9999')
+
+
+def test_normalized_address_string():
     address = Address('123 EA Fifer Place ')
-    print(address)
 
     assert address.normalized == '123 E FIFER PL'
 

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -97,3 +97,6 @@ class TestNormalizeDirection():
 
     for text in north_tests:
         assert normalize_direction(text) == 'N'
+
+    def test_two_characters(self):
+        assert normalize_direction('EA') == 'E'

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -100,3 +100,21 @@ class TestNormalizeDirection():
 
     def test_two_characters(self):
         assert normalize_direction('EA') == 'E'
+
+def test_white_space():
+    address = Address(' 123 S Main ')
+
+    assert address.address_number == '123'
+    assert address.street_name == 'MAIN'
+
+
+def test_normalizedAddressString():
+    address = Address('123 EA Fifer Place ')
+    print(address)
+
+    assert address.normalized == '123 E FIFER PL'
+
+    address = Address(' 123 east 400 w  ')
+
+    assert address.normalized == '123 E 400 W'
+

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -360,3 +360,22 @@ def test_steve():
     assert address.street_name == '50'
     assert address.street_type is None
     assert address.street_direction == 'W'
+
+
+class TestPOBox():
+    '''
+    tests for parsing PO box numbers
+    '''
+    def test_parses_po_boxes(self):
+        tests = [
+            #: input, po_box, normalized
+            ['po box 1', '1', 'PO BOX 1'],
+            ['p.o. box 2', '2', 'PO BOX 2'],
+            ['P.O. BOX G', 'G', 'PO BOX G']
+        ]
+
+        for address_input, expected_box_name, normalized in tests:
+            address = Address(address_input)
+
+            assert address.po_box == expected_box_name
+            assert address.normalized == normalized

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -29,7 +29,8 @@ class TestAddressNumberSuffix():
     '''
     def test_parses_number_suffix(self):
         tests = [
-            ['123 1/2 s main street', '1/2']
+            ['123 1/2 s main street', '1/2'],
+            ['123 A S Main St', 'A']
         ]
 
         for input_text, expected in tests:

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -13,11 +13,9 @@ class TestAddressNumber():
     '''
     tests for parsing address numbers
     '''
+
     def test_parses_address_number(self):
-        tests = [
-            ['123 main street', '123'],
-            ['4 main street', '4']
-        ]
+        tests = [['123 main street', '123'], ['4 main street', '4']]
 
         for input_text, expected in tests:
             assert Address(input_text).address_number == expected
@@ -27,11 +25,9 @@ class TestAddressNumberSuffix():
     '''
     tests for parsing address number suffixes
     '''
+
     def test_parses_number_suffix(self):
-        tests = [
-            ['123 1/2 s main street', '1/2'],
-            ['123 A S Main St', 'A']
-        ]
+        tests = [['123 1/2 s main street', '1/2'], ['123 A S Main St', 'A']]
 
         for input_text, expected in tests:
             assert Address(input_text).address_number_suffix == expected
@@ -41,13 +37,10 @@ class TestPrefixDirection():
     '''
     tests for parsing prefix directions
     '''
+
     def test_parses_prefix_direction(self):
-        tests = [
-            ['123 1/2 S main street', 'S'],
-            ['123 S main street', 'S'],
-            ['456 North main', 'N'],
-            ['123 EA Some Street', 'E']
-        ]
+        tests = [['123 1/2 S main street', 'S'], ['123 S main street', 'S'], ['456 North main', 'N'], ['123 EA Some Street', 'E'], ['9258 So 3090 W', 'S'],
+                 ['9258 SO. 3090 w', 'S']]
 
         for input_text, expected in tests:
             assert Address(input_text).prefix_direction == expected
@@ -67,10 +60,13 @@ class TestStreetName():
     '''
     tests for parsing street names
     '''
+
     def test_parses_street_name(self):
         tests = [
             ['123 S main street', 'MAIN'],
-            ['456 North main', 'MAIN']
+            ['456 North main', 'MAIN'],
+            ['9258 w 3090 so.', '3090'],
+            ['9258 w 3090 so', '3090'],
         ]
 
         for input_text, expected in tests:
@@ -92,6 +88,7 @@ class TestStreetDirection():
     '''
     tests for parsing suffix directions
     '''
+
     def test_street_direction(self):
         address = Address('123 E 400 N')
 
@@ -103,25 +100,23 @@ class TestNormalizeDirection():
     '''
     tests for normalizing cardinal directions
     '''
+
     def test_normalize_direction(self):
-        north_tests = [
-            'North',
-            'N',
-            'north',
-            'n'
-        ]
+        north_tests = ['North', 'N', 'north', 'n']
 
         for text in north_tests:
             assert normalize_direction(text) == 'N'
 
     def test_two_characters(self):
         assert normalize_direction('EA') == 'E'
+        assert normalize_direction('SO') == 'S'
 
 
 class TestWhiteSpace():
     '''
     tests for dealing with white space
     '''
+
     def test_white_space(self):
         address = Address(' 123 S Main ')
 
@@ -141,12 +136,9 @@ class TestNormalizeStreetType():
     '''
     tests for normalizing street types
     '''
+
     def test_normalize_street_type(self):
-        tests = [
-            ['ALY', 'ALY'],
-            ['AVEN', 'AVE'],
-            ['corner', 'COR']
-        ]
+        tests = [['ALY', 'ALY'], ['AVEN', 'AVE'], ['corner', 'COR']]
 
         for input_text, expected in tests:
             assert normalize_street_type(input_text) == expected
@@ -182,6 +174,7 @@ class TestUnitParts():
     '''
     tests for unit_type and unit_id
     '''
+
     def test_add_hash_if_no_type(self):
         address = Address('123 s main st 3')
 
@@ -200,6 +193,26 @@ class TestUnitParts():
         assert address.unit_id == '3'
 
 
+class TestPOBox():
+    '''
+    tests for parsing PO box numbers
+    '''
+
+    def test_parses_po_boxes(self):
+        tests = [
+            #: input, po_box, normalized
+            ['po box 1', '1', 'PO BOX 1'],
+            ['p.o. box 2', '2', 'PO BOX 2'],
+            ['P.O. BOX G', 'G', 'PO BOX G']
+        ]
+
+        for address_input, expected_box_name, normalized in tests:
+            address = Address(address_input)
+
+            assert address.po_box == expected_box_name
+            assert address.normalized == normalized
+
+
 def test_normalized_address_string():
     address = Address('123 EA Fifer Place ')
 
@@ -208,7 +221,6 @@ def test_normalized_address_string():
     address = Address(' 123 east 400 w  ')
 
     assert address.normalized == '123 E 400 W'
-
 
 
 def test_strip_periods():
@@ -360,22 +372,3 @@ def test_steve():
     assert address.street_name == '50'
     assert address.street_type is None
     assert address.street_direction == 'W'
-
-
-class TestPOBox():
-    '''
-    tests for parsing PO box numbers
-    '''
-    def test_parses_po_boxes(self):
-        tests = [
-            #: input, po_box, normalized
-            ['po box 1', '1', 'PO BOX 1'],
-            ['p.o. box 2', '2', 'PO BOX 2'],
-            ['P.O. BOX G', 'G', 'PO BOX G']
-        ]
-
-        for address_input, expected_box_name, normalized in tests:
-            address = Address(address_input)
-
-            assert address.po_box == expected_box_name
-            assert address.normalized == normalized

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -7,7 +7,11 @@ tests for the address parser module
 from .address_parser import Address, normalize_direction
 
 
-def test_parses_address_number():
+class TestAddressNumber():
+    '''
+    tests for parsing address numbers
+    '''
+    def test_parses_address_number(self):
     tests = [
         ['123 main street', '123'],
         ['4 main street', '4']
@@ -16,16 +20,41 @@ def test_parses_address_number():
     for input_text, expected in tests:
         assert Address(input_text).address_number == expected
 
-def test_parses_prefix_direction():
+
+class TestAddressNumberSuffix():
+    '''
+    tests for parsing address number suffixes
+    '''
+    def test_parses_address_number_suffix(self):
     tests = [
+            ['123 1/2 s main street', '1/2']
+        ]
+
+        for input_text, expected in tests:
+            assert Address(input_text).address_number_suffix == expected
+
+
+class TestPrefixDirection():
+    '''
+    tests for parsing prefix directions
+    '''
+    def test_parses_prefix_direction(self):
+        tests = [
+            ['123 1/2 S main street', 'S'],
         ['123 S main street', 'S'],
-        ['456 North main', 'N']
+            ['456 North main', 'N'],
+            ['123 EA Some Street', 'E']
     ]
 
     for input_text, expected in tests:
         assert Address(input_text).prefix_direction == expected
 
-def test_parses_street_name():
+
+class TestStreetName():
+    '''
+    tests for parsing street names
+    '''
+    def test_parses_street_name(self):
     tests = [
         ['123 S main street', 'MAIN'],
         ['456 North main', 'MAIN']
@@ -34,7 +63,31 @@ def test_parses_street_name():
     for input_text, expected in tests:
         assert Address(input_text).street_name == expected
 
-def test_normalize_direction():
+    def test_multi_word_street_name(self):
+        address = Address('123 S Main Hello Street')
+
+        assert address.street_name == 'MAIN HELLO'
+
+    def test_no_prefix_direction_street_name(self):
+        address = Address('123 Main Street')
+
+        assert address.street_name == 'MAIN'
+        assert address.prefix_direction is None
+
+
+class TestStreetDirection():
+    '''
+    tests for parsing suffix directions
+    '''
+    def test_street_direction(self):
+        address = Address('123 E 400 N')
+
+        assert address.street_direction == 'N'
+        assert address.street_type is None
+
+
+class TestNormalizeDirection():
+    def test_normalize_direction(self):
     north_tests = [
         'North',
         'N',

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+# * coding: utf8 *
+'''
+test_address_parser.py
+tests for the address parser module
+'''
+from .address_parser import Address, normalize_direction
+
+
+def test_parses_address_number():
+    tests = [
+        ['123 main street', '123'],
+        ['4 main street', '4']
+    ]
+
+    for input_text, expected in tests:
+        assert Address(input_text).address_number == expected
+
+def test_parses_prefix_direction():
+    tests = [
+        ['123 S main street', 'S'],
+        ['456 North main', 'N']
+    ]
+
+    for input_text, expected in tests:
+        assert Address(input_text).prefix_direction == expected
+
+def test_parses_street_name():
+    tests = [
+        ['123 S main street', 'MAIN'],
+        ['456 North main', 'MAIN']
+    ]
+
+    for input_text, expected in tests:
+        assert Address(input_text).street_name == expected
+
+def test_normalize_direction():
+    north_tests = [
+        'North',
+        'N',
+        'north',
+        'n'
+    ]
+
+    for text in north_tests:
+        assert normalize_direction(text) == 'N'

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -110,6 +110,8 @@ class TestNormalizeDirection():
     def test_two_characters(self):
         assert normalize_direction('EA') == 'E'
         assert normalize_direction('SO') == 'S'
+        assert normalize_direction('WE') == 'W'
+        assert normalize_direction('NO') == 'N'
 
 
 class TestWhiteSpace():

--- a/src/sweeper/test_address_parser.py
+++ b/src/sweeper/test_address_parser.py
@@ -51,6 +51,16 @@ class TestPrefixDirection():
         for input_text, expected in tests:
             assert Address(input_text).prefix_direction == expected
 
+    def test_no_prefix_direction(self):
+        address = Address('1901 Sidewinder Dr')
+
+        assert address.address_number == '1901'
+        assert address.prefix_direction is None
+        assert address.street_name == 'SIDEWINDER'
+        assert address.street_type == 'DR'
+        assert address.street_direction is None
+        assert address.normalized == '1901 SIDEWINDER DR'
+
 
 class TestStreetName():
     '''
@@ -106,11 +116,24 @@ class TestNormalizeDirection():
     def test_two_characters(self):
         assert normalize_direction('EA') == 'E'
 
-def test_white_space():
-    address = Address(' 123 S Main ')
 
-    assert address.address_number == '123'
-    assert address.street_name == 'MAIN'
+class TestWhiteSpace():
+    '''
+    tests for dealing with white space
+    '''
+    def test_white_space(self):
+        address = Address(' 123 S Main ')
+
+        assert address.address_number == '123'
+        assert address.street_name == 'MAIN'
+
+    def test_double_spaces(self):
+        address = Address('  123  ea main  st')
+
+        assert address.address_number == '123'
+        assert address.prefix_direction == 'E'
+        assert address.street_name == 'MAIN'
+        assert address.street_type == 'ST'
 
 
 class TestNormalizeStreetType():
@@ -131,6 +154,28 @@ class TestNormalizeStreetType():
         with pytest.raises(InvalidStreetTypeError):
             normalize_street_type('9999')
 
+    def test_street_names_with_types(self):
+        '''
+        street names with types as part of the name
+        '''
+        address = Address('123 E PARKWAY AVE')
+
+        assert address.address_number == '123'
+        assert address.prefix_direction == 'E'
+        assert address.street_name == 'PARKWAY'
+        assert address.street_type == 'AVE'
+        assert address.street_direction is None
+        assert address.normalized == '123 E PARKWAY AVE'
+
+        address = Address('123 E PARKWAY TRAIL AVE')
+
+        assert address.address_number == '123'
+        assert address.prefix_direction == 'E'
+        assert address.street_name == 'PARKWAY TRAIL'
+        assert address.street_type == 'AVE'
+        assert address.street_direction is None
+        assert address.normalized == '123 E PARKWAY TRAIL AVE'
+
 
 def test_normalized_address_string():
     address = Address('123 EA Fifer Place ')
@@ -141,8 +186,6 @@ def test_normalized_address_string():
 
     assert address.normalized == '123 E 400 W'
 
-    # def test_doubleSpaces(self):
-    #     address = Address('  123  ea main  st')
 
 
 def test_strip_periods():
@@ -155,158 +198,142 @@ def test_strip_periods():
     assert address.street_direction is None
     assert address.normalized == '123 E MAIN ST'
 
-    # # tests from Steve's geocoder...
-    # def test_steves(self):
-    #     address = Address("5301 w jacob hill cir")
-    #     assert '5301' == address.houseNumber
-    #     assert "JACOB HILL" == address.streetName
-    #     assert 'CIR' == address.suffix_type
 
-    #     address = Address("400 S 532 E")
-    #     assert '400' == address.houseNumber
-    #     assert "532" == address.streetName
-    #     assert 'E' == address.suffix_direction
+def test_steve():
+    '''
+    tests from steve's geocoder
+    '''
+    address = Address('5301 w jacob hill cir')
+    assert address.address_number == '5301'
+    assert address.street_name == 'JACOB HILL'
+    assert address.street_type == 'CIR'
 
-    #     address = Address("5625 S 995 E")
-    #     assert '5625' == address.houseNumber
-    #     assert "995" == address.streetName
-    #     assert 'E' == address.suffix_direction
+    address = Address('400 S 532 E')
+    assert address.address_number == '400'
+    assert address.street_name == '532'
+    assert address.street_direction == 'E'
 
-    #     address = Address("372 North 600 East")
-    #     assert '372' == address.houseNumber
-    #     assert "600" == address.streetName
-    #     assert 'E' == address.suffix_direction
+    address = Address('5625 S 995 E')
+    assert address.address_number == '5625'
+    assert address.street_name == '995'
+    assert address.street_direction == 'E'
 
-    #     address = Address("30 WEST 300 NORTH")
-    #     assert '30' == address.houseNumber
-    #     assert "300" == address.streetName
-    #     assert 'N' == address.suffix_direction
+    address = Address('372 North 600 East')
+    assert address.address_number == '372'
+    assert address.street_name == '600'
+    assert address.street_direction == 'E'
 
-    #     address = Address("126 E 400 N")
-    #     assert '126' == address.houseNumber
-    #     assert "400" == address.streetName
-    #     assert 'N' == address.suffix_direction
+    address = Address('30 WEST 300 NORTH')
+    assert address.address_number == '30'
+    assert address.street_name == '300'
+    assert address.street_direction == 'N'
 
-    #     address = Address("270 South 1300 East")
-    #     assert '270' == address.houseNumber
-    #     assert "1300" == address.streetName
-    #     assert 'E' == address.suffix_direction
+    address = Address('126 E 400 N')
+    assert address.address_number == '126'
+    assert address.street_name == '400'
+    assert address.street_direction == 'N'
 
-    #     address = Address("126 W SEGO LILY DR")
-    #     assert '126' == address.houseNumber
-    #     assert "SEGO LILY" == address.streetName
-    #     assert 'DR' == address.suffix_type
+    address = Address('270 South 1300 East')
+    assert address.address_number == '270'
+    assert address.street_name == '1300'
+    assert address.street_direction == 'E'
 
-    #     address = Address("261 E MUELLER PARK RD")
-    #     assert '261' == address.houseNumber
-    #     assert "MUELLER PARK" == address.streetName
-    #     assert 'RD' == address.suffix_type
+    address = Address('126 W SEGO LILY DR')
+    assert address.address_number == '126'
+    assert address.street_name == 'SEGO LILY'
+    assert address.street_type == 'DR'
 
-    #     address = Address("17 S VENICE MAIN ST")
-    #     assert '17' == address.houseNumber
-    #     assert "VENICE MAIN" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    address = Address('261 E MUELLER PARK RD')
+    assert address.address_number == '261'
+    assert address.street_name == 'MUELLER PARK'
+    assert address.street_type == 'RD'
 
-    #     address = Address("20 W Center St")
-    #     assert '20' == address.houseNumber
-    #     assert 'W' == address.prefixDirection
-    #     assert "CENTER" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    address = Address('17 S VENICE MAIN ST')
+    assert address.address_number == '17'
+    assert address.street_name == 'VENICE MAIN'
+    assert address.street_type == 'ST'
 
-    #     address = Address("9314 ALVEY LN")
-    #     assert '9314' == address.houseNumber
-    #     assert "ALVEY" == address.streetName
-    #     assert 'LN' == address.suffix_type
+    address = Address('20 W Center St')
+    assert address.address_number == '20'
+    assert address.prefix_direction == 'W'
+    assert address.street_name == 'CENTER'
+    assert address.street_type == 'ST'
 
-    #     address = Address("167 DALY AVE")
-    #     assert '167' == address.houseNumber
-    #     assert "DALY" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('9314 ALVEY LN')
+    assert address.address_number == '9314'
+    assert address.street_name == 'ALVEY'
+    assert address.street_type == 'LN'
 
-    #     address = Address("1147 MCDANIEL CIR")
-    #     assert '1147' == address.houseNumber
-    #     assert "MCDANIEL" == address.streetName
-    #     assert 'CIR' == address.suffix_type
+    address = Address('167 DALY AVE')
+    assert address.address_number == '167'
+    assert address.street_name == 'DALY'
+    assert address.street_type == 'AVE'
 
-    #     address = Address("300 Walk St")
-    #     assert '300' == address.houseNumber
-    #     assert "WALK" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    address = Address('1147 MCDANIEL CIR')
+    assert address.address_number == '1147'
+    assert address.street_name == 'MCDANIEL'
+    assert address.street_type == 'CIR'
 
-    #     address = Address("5 Cedar Ave")
-    #     assert '5' == address.houseNumber
-    #     assert "CEDAR" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('300 Walk St')
+    assert address.address_number == '300'
+    assert address.street_name == 'WALK'
+    assert address.street_type == 'ST'
 
-    #     address = Address("1238 E 1ST Avenue")
-    #     assert '1238' == address.houseNumber
-    #     assert "1ST" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('5 Cedar Ave')
+    assert address.address_number == '5'
+    assert address.street_name == 'CEDAR'
+    assert address.street_type == 'AVE'
 
-    #     address = Address("1238 E FIRST Avenue")
-    #     assert '1238' == address.houseNumber
-    #     assert "FIRST" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('1238 E 1ST Avenue')
+    assert address.address_number == '1238'
+    assert address.street_name == '1ST'
+    assert address.street_type == 'AVE'
 
-    #     address = Address("1238 E 2ND Avenue")
-    #     assert '1238' == address.houseNumber
-    #     assert "2ND" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('1238 E FIRST Avenue')
+    assert address.address_number == '1238'
+    assert address.street_name == 'FIRST'
+    assert address.street_type == 'AVE'
 
-    #     address = Address("1238 E 3RD Avenue")
-    #     assert '1238' == address.houseNumber
-    #     assert "3RD" == address.streetName
-    #     assert 'AVE' == address.suffix_type
+    address = Address('1238 E 2ND Avenue')
+    assert address.address_number == '1238'
+    assert address.street_name == '2ND'
+    assert address.street_type == 'AVE'
 
-    #     address = Address("1573 24TH Street")
-    #     assert '1573' == address.houseNumber
-    #     assert "24TH" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    address = Address('1238 E 3RD Avenue')
+    assert address.address_number == '1238'
+    assert address.street_name == '3RD'
+    assert address.street_type == 'AVE'
 
-    #     # if you dont' have a street name but you have a prefix direction then the
-    #     # prefix diretion is probably the street name.
-    #     address = Address("168 N ST")
-    #     assert '168' == address.houseNumber
-    #     assert "N" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    address = Address('1573 24TH Street')
+    assert address.address_number == '1573'
+    assert address.street_name == '24TH'
+    assert address.street_type == 'ST'
 
-    #     address = Address("168 N N ST")
-    #     assert '168' == address.houseNumber
-    #     assert "N" == address.streetName
-    #     assert 'ST' == address.suffix_type
+    # if you don't have a street name but you have a prefix direction then the
+    # prefix direction is probably the street name.
+    address = Address('168 N ST')
+    assert address.address_number == '168'
+    assert address.street_name == 'N'
+    assert address.street_type == 'ST'
 
-    #     address = Address("478 S WEST FRONTAGE RD")
-    #     assert '478' == address.houseNumber
-    #     assert "WEST FRONTAGE" == address.streetName
-    #     assert 'RD' == address.suffix_type
+    address = Address('168 N N ST')
+    assert address.address_number == '168'
+    assert address.street_name == 'N'
+    assert address.street_type == 'ST'
 
-    #     address = Address("1048 W 1205 N")
-    #     assert '1048' == address.houseNumber
-    #     assert "1205" == address.streetName
-    #     assert None == address.suffix_type
-    #     assert 'N' == address.suffix_direction
+    address = Address('478 S WEST FRONTAGE RD')
+    assert address.address_number == '478'
+    assert address.street_name == 'WEST FRONTAGE'
+    assert address.street_type == 'RD'
 
-    #     address = Address("2139 N 50 W")
-    #     assert '2139' == address.houseNumber
-    #     assert "50" == address.streetName
-    #     assert None == address.suffix_type
-    #     assert 'W' == address.suffix_direction
+    address = Address('1048 W 1205 N')
+    assert address.address_number == '1048'
+    assert address.street_name == '1205'
+    assert address.street_type is None
+    assert address.street_direction == 'N'
 
-    # def test_streetTypeNames(self):
-    #     address = Address('123 E PARKWAY AVE')
-
-    #     assert address.houseNumber == '123'
-    #     assert address.prefixDirection == 'E'
-    #     assert address.streetName == 'PARKWAY'
-    #     assert address.suffix_type == 'AVE'
-    #     assert address.suffix_direction == None
-    #     assert address.normalizedAddressString == '123 E PARKWAY AVE'
-
-    #     address = Address('123 E PARKWAY TRAIL AVE')
-
-    #     assert address.houseNumber == '123'
-    #     assert address.prefixDirection == 'E'
-    #     assert address.streetName == 'PARKWAY TRAIL'
-    #     assert address.suffix_type == 'AVE'
-    #     assert address.suffix_direction == None
-    #     assert address.normalizedAddressString == '123 E PARKWAY TRAIL AVE'
+    address = Address('2139 N 50 W')
+    assert address.address_number == '2139'
+    assert address.street_name == '50'
+    assert address.street_type is None
+    assert address.street_direction == 'W'


### PR DESCRIPTION
~This is nowhere close to being finished. Just wanted to open this up and get opinions on the direction that I'm taking...~

I believe that the address parser is to a point of being useable and would like to get this merged. I've still got open issues, but I think that they can go in subsequent PRs. I'd like to get this into users' hands for feedback.

The basic API looks like this:
```python
from sweeper.address_parser import Address

address = Address('123 south main street')
print(address.address_number) #: '123'
print(address.prefix_direction) #: 'S'
```