### PR TITLE
More Magnificent Metadata Magic for Monday

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "AVEN",
         "DALY",
         "MCDANIEL",
+        "Plss",
         "SEGO",
         "bdist",
         "conda",
@@ -24,5 +25,5 @@
     ],
     "python.linting.pylintEnabled": true,
     "python.linting.enabled": true,
-    "python.pythonPath": "C:\\Users\\gbunce\\AppData\\Local\\Programs\\ArcGIS\\Pro\\bin\\Python\\envs\\sweeper\\python.exe"
+    "python.pythonPath": "C:\\Users\\agrc-arcgis\\AppData\\Local\\ESRI\\conda\\envs\\sweeper\\python.exe"
 }

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include src/sweeper/*.json
+include src/sweeper/sweepers/*.html

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,24 @@
 
 fix data
 
+## Available Sweepers
+
+### addresses
+
+Checks that addresses have minimum required parts and optionally normalizes them.
+
+### duplicates
+
+Checks for duplicate features.
+
+### empties
+
+Checks for empty geometries.
+
+### metadata
+
+Checks to make sure that the metadata meets [the SGID Metadata Minimum Requirements Document](https://docs.google.com/document/d/1VkXRwfSn6MraI1VeLfei5tg6je4bd2pp_Vh1JuST9xs/edit).
+
 ## Parsing Addresses
 
 This project contains a module that can be used as a standalone address parser, `sweeper.address_parser`. This allows developer to take advantage of sweepers advanced address parsing and normalization without having to run the entire sweeper process.

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
         'docopt==0.6.*',
         'xxhash==1.4.*',
         'usaddress==0.5.*',
+        'beautifulsoup4==4.8.*'
     ],
     dependency_links=[],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -38,8 +38,8 @@ setup(
     keywords=[],
     install_requires=[
         'docopt==0.6.*',
-        'xxhash',
-        'usaddress'
+        'xxhash==1.4.*',
+        'usaddress==0.5.*',
     ],
     dependency_links=[],
     extras_require={

--- a/src/sweeper/__main__.py
+++ b/src/sweeper/__main__.py
@@ -4,12 +4,12 @@
 sweeper
 
 Usage:
-  sweeper sweep duplicates  --workspace=<workspace> --table-name=<table_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
-  sweeper sweep empties     --workspace=<workspace> --table-name=<table_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
-  sweeper sweep invalids    --workspace=<workspace> --table-name=<table_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
-  sweeper sweep addresses   --workspace=<workspace> --table-name=<table_name> --field-name=<field_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
-  sweeper sweep metadata    --workspace=<workspace> --table-name=<table_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
-  sweeper sweep             --workspace=<workspace> --table-name=<table_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep duplicates  --workspace=<workspace> [--table-name=<table_name> --verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep empties     --workspace=<workspace> [--table-name=<table_name> --verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep invalids    --workspace=<workspace> [--table-name=<table_name> --verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep addresses   --workspace=<workspace> --table-name=<table-name> --field-name=<field_name> [--verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep metadata    --workspace=<workspace> [--table-name=<table_name> --verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
+  sweeper sweep             --workspace=<workspace> [--table-name=<table_name> --verbose --try-fix --save-report=<report_path> --backup-to=<backup_path>]
 
 Arguments:
   workspace     - path to workspace eg: `c:\\my.gdb`

--- a/src/sweeper/sweepers/UseLimitations.html
+++ b/src/sweeper/sweepers/UseLimitations.html
@@ -1,0 +1,10 @@
+<p>
+    The data herein, including but not limited to geographic data, tabular data, analytical data, electronic data structures or files, are provided &quot;as is&quot; without warranty of any kind, either expressed or implied, or statutory, including, but not limited to, the implied warranties or merchantability and fitness for a particular purpose. The entire risk as to the quality and performance of the data is assumed by the user.
+</p>
+
+<p>
+    <a href="http://creativecommons.org/licenses/by/4.0/">
+        <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" style="border-width:0;" />
+    </a>
+    <br />This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+</p>

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -10,6 +10,42 @@ from arcpy import metadata as md
 from arcpy import EnvManager, ListFeatureClasses, ListTables
 
 
+#: these constants were copied from https://github.com/agrc/agol-validator/blob/master/validate.py
+#: Tags or words that should be uppercased, saved as lower to check against
+UPPERCASED_TAGS = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat', 'caf', 'cdl', 'daq', 'dfcm', 'dfirm', 'dwq', 'e911', 'ems', 'fae', 'fcc', 'fema', 'gcdb', 'gis', 'gnis', 'hava', 'huc', 'lir', 'lrs', 'lte', 'luca', 'mrrc', 'nca', 'ng911', 'nox', 'npsbn', 'ntia', 'nwi', 'plss', 'pm10', 'psap', 'sao', 'sbdc', 'sbi', 'sgid', 'sitla', 'sligp', 'trax', 'uca', 'udot', 'ugs', 'uhp', 'uic', 'us', 'usao', 'usdw', 'usfs', 'usfws', 'usps', 'ustc', 'ut', 'uta', 'vcp', 'vista', 'voc']
+#: Articles that should be left lowercase.
+ARTICLES = ['a', 'the', 'of', 'is', 'in']
+
+
+#: copied from https://github.com/agrc/agol-validator/blob/master/checks.py with minor modifications
+def title_case_tag(tag):
+    '''
+    Changes a tag to the correct title case while also removing any periods:
+    'U.S. bureau Of Geoinformation' -> 'US Bureau of Geoinformation'. Should
+    properly upper-case any words or single tags that are acronyms:
+    'agrc' -> 'AGRC', 'Plss Fabric' -> 'PLSS Fabric'. Any words separated by
+    a hyphen will also be title-cased: 'water-related' -> 'Water-Related'.
+    Note: No check is done for articles at the begining of a tag; all articles
+    will be lowercased.
+    tag:        The single or multi-word tag to check
+    '''
+
+    new_words = []
+    for word in tag.split():
+        cleaned_word = word.replace('.', '').lower()
+
+        #: Upper case specified words:
+        if cleaned_word.lower() in UPPERCASED_TAGS:
+            new_words.append(cleaned_word.upper())
+        #: Lower case articles/conjunctions
+        elif cleaned_word.lower() in ARTICLES:
+            new_words.append(cleaned_word.lower())
+        #: Title case everything else
+        else:
+            new_words.append(cleaned_word.title())
+
+    return ' '.join(new_words)
+
 class MetadataTest():
     '''A class that validates geodatabase metadata
     '''
@@ -38,6 +74,13 @@ class MetadataTest():
 
         if len(missing_tags):
             report['issues'].append(f'missing tags: {required_tags}')
+
+        if metadata.tags is not None:
+            #: check casing for existing tags
+            for tag in tags:
+                formatted_tag = title_case_tag(tag)
+                if tag != formatted_tag:
+                    report['issues'].append(f'incorrectly cased tag: {tag} (should be: {formatted_tag})')
 
         return report
 

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -24,12 +24,19 @@ class MetadataTest():
 
         name_parts = self.table_name.split('.')
 
+        #: check for required tags
         required_tags = []
         if len(name_parts) == 3:
             [database, schema, feature_class_name] = name_parts
             required_tags.append(database)
             required_tags.append(schema.title())
-        if metadata.tags is None or len(metadata.tags) == 0:
+        if metadata.tags is None:
+            missing_tags = required_tags
+        else:
+            tags = [tag.strip() for tag in metadata.tags.split(',')]
+            missing_tags = set(required_tags) - set(tags)
+
+        if len(missing_tags):
             report['issues'].append(f'missing tags: {required_tags}')
 
         return report

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -81,7 +81,11 @@ class MetadataTest():
     def sweep(self):
         report = {'title': 'Metadata Test', 'workspace': self.workspace, 'feature_class': self.table_name, 'issues': []}
 
-        metadata = md.Metadata(join(self.workspace, self.table_name))
+        table_path = join(self.workspace, self.table_name)
+
+        if not Exists(table_path):
+            raise Exception(f'dataset does not exist! {table_path}')
+        metadata = md.Metadata(table_path)
 
         name_parts = self.table_name.split('.')
 

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -51,6 +51,9 @@ def title_case_tag(tag):
 
 
 def get_tags_from_string(text):
+    if text is None:
+        return []
+
     return [tag.strip() for tag in text.split(',')]
 
 

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -6,6 +6,7 @@ A sweeper that checks geodatabase metadata
 '''
 from os.path import join
 from bs4 import BeautifulSoup
+import re
 
 from arcpy import metadata as md
 from arcpy import EnvManager, ListFeatureClasses, ListTables
@@ -17,6 +18,7 @@ UPPERCASED_TAGS = ['2g', '3g', '4g', 'agol', 'agrc', 'aog', 'at&t', 'blm', 'brat
 #: Articles that should be left lowercase.
 ARTICLES = ['a', 'the', 'of', 'is', 'in']
 
+DATA_PAGE_LINK_REGEX = re.compile(r'gis\.utah\.gov.*\/data', re.IGNORECASE)
 
 #: copied from https://github.com/agrc/agol-validator/blob/master/checks.py with minor modifications
 def title_case_tag(tag):
@@ -112,6 +114,12 @@ class MetadataTest():
             description_text = get_description_text_only(metadata.description)
             if len(metadata.summary) > len(description_text):
                 report['issues'].append('Summary is longer than Description!')
+
+        #: check description for data page link
+        if metadata.description is not None:
+            if not DATA_PAGE_LINK_REGEX.search(metadata.description):
+                report['issues'].append('Description is missing link to gis.utah.gov data page.')
+
         return report
 
     def try_fix(self):

--- a/src/sweeper/tests/test_metadata.py
+++ b/src/sweeper/tests/test_metadata.py
@@ -7,7 +7,7 @@ a module that tests the metadata sweeper
 from os import path
 from unittest import TestCase
 
-from ..sweepers.metadata import MetadataTest, title_case_tag
+from ..sweepers.metadata import MetadataTest, title_case_tag, update_tags
 
 current_folder = path.dirname(__file__)
 workspace = path.join(current_folder, 'data', 'Sweeper as CADASTRE.sde')
@@ -39,3 +39,12 @@ class TestTitleCaseTag(TestCase):
 
         for input_tag, expected in tests:
             assert title_case_tag(input_tag) == expected
+
+
+class TestUpdateTags(TestCase):
+
+    def test_update_tags(self):
+        results = update_tags(['a', 'b', 'c', 'd'], ['b', 'c'], ['B', 'E'])
+        expected = ['a', 'd', 'B', 'E']
+
+        assert results == expected

--- a/src/sweeper/tests/test_metadata.py
+++ b/src/sweeper/tests/test_metadata.py
@@ -7,17 +7,35 @@ a module that tests the metadata sweeper
 from os import path
 from unittest import TestCase
 
-from ..sweepers.metadata import MetadataTest
-
+from ..sweepers.metadata import MetadataTest, title_case_tag
 
 current_folder = path.dirname(__file__)
 workspace = path.join(current_folder, 'data', 'Sweeper as CADASTRE.sde')
 
 
 class TestMetadataSweeper(TestCase):
+
     def test_no_tags(self):
         tool = MetadataTest(workspace, 'Sweeper.CADASTRE.MissingTags')
         report = tool.sweep()
 
         assert len(report['issues']) == 1
         self.assertRegex(report['issues'][0], r'missing tags')
+
+    def test_title_cased_tags(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.IncorrectCasing')
+        report = tool.sweep()
+
+        assert len(report['issues']) == 3
+        self.assertRegex(report['issues'][0], r'incorrectly cased tag')
+
+
+class TestTitleCaseTag(TestCase):
+
+    def test_title_case_tag(self):
+        #: input, expected
+        tests = [['agrc', 'AGRC'], ['Plss Fabric', 'PLSS Fabric'], ['water-related', 'Water-Related'], ['test', 'Test'],
+                 ['article is a good test', 'Article is a Good Test']]
+
+        for input_tag, expected in tests:
+            assert title_case_tag(input_tag) == expected

--- a/src/sweeper/tests/test_metadata.py
+++ b/src/sweeper/tests/test_metadata.py
@@ -7,7 +7,7 @@ a module that tests the metadata sweeper
 from os import path
 from unittest import TestCase
 
-from ..sweepers.metadata import MetadataTest, title_case_tag, update_tags
+from ..sweepers.metadata import MetadataTest, title_case_tag, update_tags, get_description_text_only
 
 current_folder = path.dirname(__file__)
 workspace = path.join(current_folder, 'data', 'Sweeper as CADASTRE.sde')
@@ -48,3 +48,31 @@ class TestUpdateTags(TestCase):
         expected = ['a', 'd', 'B', 'E']
 
         assert results == expected
+
+
+class TestSummary(TestCase):
+
+    def test_summary_longer_than_description(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.SummaryLongerThanDescription')
+        report = tool.sweep()
+
+        assert len(report['issues']) == 1
+        self.assertRegex(report['issues'][0], r'Summary is longer than Description')
+
+    def test_summary_too_long(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.SummaryTooLong')
+        report = tool.sweep()
+
+        assert len(report['issues']) == 1
+        self.assertRegex(report['issues'][0], r'Summary is longer than')
+
+
+class TestDescriptionParsing(TestCase):
+
+    def test_get_description_text_only(self):
+        input = '<DIV STYLE="text-align:Left;"><DIV><P><SPAN>This is a short description.</SPAN></P></DIV></DIV>'
+
+        assert get_description_text_only(input) == 'This is a short description.'
+
+    def test_handles_none(self):
+        assert get_description_text_only(None) == ''

--- a/src/sweeper/tests/test_metadata.py
+++ b/src/sweeper/tests/test_metadata.py
@@ -102,3 +102,26 @@ class TestDescriptionChecks(TestCase):
         report = tool.sweep()
 
         assert does_not_contain_issue_with_text(report['issues'], 'Description is missing link')
+
+
+class TestUseLimitation(TestCase):
+
+    def test_correct_use_limitation(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.CorrectUseLimitations')
+        report = tool.sweep()
+
+        assert does_not_contain_issue_with_text(report['issues'], 'Use limitations')
+
+    def test_incorrect_use_limitation(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.WithBadUseLimitations')
+        report = tool.sweep()
+
+        assert contains_issue_with_text(report['issues'], 'Use limitations text is not standard')
+        assert tool.use_limitations_needs_update
+
+    def test_no_use_limitation(self):
+        tool = MetadataTest(workspace, 'Sweeper.CADASTRE.WithoutUseLimitations')
+        report = tool.sweep()
+
+        assert contains_issue_with_text(report['issues'], 'Use limitations text is missing')
+        assert tool.use_limitations_needs_update


### PR DESCRIPTION
Implements: casing check and try-fix for tags.
Closes #47

Implements: summary checks.
Closes #48 

Implements: description check for gis.utah.gov data page link
Closes #49

Implements: use limitations check
Closes #50 

Here's what the report looks like for SGID (internal):
```
Metadata Test Report for SGID.BIOSCIENCE.WildfirePerimeters
2 issues found:
    missing tags: ['SGID', 'Bioscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BIOSCIENCE.FirePerimeters
2 issues found:
    missing tags: ['SGID', 'Bioscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BIOSCIENCE.DominantVegetation
7 issues found:
    missing tags: {'SGID', 'Bioscience'}
    incorrectly cased tag: biota (should be: Biota)
    incorrectly cased tag: boundaries (should be: Boundaries)
    incorrectly cased tag: environment (should be: Environment)
    incorrectly cased tag: farming (should be: Farming)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.UtahInlandPortAuthority_HB2001
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Wilderness_BLM98Reinventory
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.UtahConservationDistricts
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.UtahConservationZones
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Wilderness_BLMSuitability
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.USFSRoadlessInventory
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.USFSWildernessAreas
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Wilderness_BLMWSAs
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.NavajoChapters
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.Municipalities_Carto
4 issues found:
    missing tags: {'SGID'}
    incorrectly cased tag: Cartographic representation (should be: Cartographic Representation)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.Municipalities_Modifications
4 issues found:
    missing tags: {'SGID', 'Boundaries'}
    incorrectly cased tag: MunicipalBoundaries_Modifications (should be: Municipalboundaries_Modifications)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.SchoolDistricts
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Municipalities
4 issues found:
    missing tags: {'SGID', 'Boundaries'}
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.ZipCodes
3 issues found:
    missing tags: {'SGID', 'Boundaries'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.MetroTownships
5 issues found:
    missing tags: {'SGID', 'Boundaries'}
    incorrectly cased tag: Townships. (should be: Townships)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.USStates
13 issues found:
    missing tags: {'SGID', 'Boundaries'}
    incorrectly cased tag: polygon (should be: Polygon)
    incorrectly cased tag: area (should be: Area)
    incorrectly cased tag: detail (should be: Detail)
    incorrectly cased tag: demographics (should be: Demographics)
    incorrectly cased tag: population (should be: Population)
    incorrectly cased tag: households (should be: Households)
    incorrectly cased tag: farm information (should be: Farm Information)
    incorrectly cased tag: boundaries (should be: Boundaries)
    incorrectly cased tag: society (should be: Society)
    incorrectly cased tag: U.S. States (should be: US States)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.GrandStaircaseEscalanteNM
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Utah
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.ForestService
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Counties_Modifications
4 issues found:
    missing tags: ['SGID', 'Boundaries']
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.Counties_LabelLines
5 issues found:
    missing tags: {'SGID', 'Boundaries'}
    incorrectly cased tag: Boundaries lines (should be: Boundaries Lines)
    incorrectly cased tag: boundaries lines (should be: Boundaries Lines)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.Counties
4 issues found:
    missing tags: {'SGID'}
    incorrectly cased tag: boundaries (should be: Boundaries)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.BLMMonumentsAndNCAs_Historic
3 issues found:
    missing tags: {'SGID', 'Boundaries'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.BLMMonumentsAndNCAs
15 issues found:
    missing tags: {'SGID', 'Boundaries'}
    incorrectly cased tag: boundaries (should be: Boundaries)
    incorrectly cased tag: environment (should be: Environment)
    incorrectly cased tag: location (should be: Location)
    incorrectly cased tag: structure (should be: Structure)
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    incorrectly cased tag: location (should be: Location)
    incorrectly cased tag: structure (should be: Structure)
    incorrectly cased tag: environment (should be: Environment)
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    incorrectly cased tag: geoscientificInformation (should be: Geoscientificinformation)
    incorrectly cased tag: boundaries (should be: Boundaries)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.BOUNDARIES.BLMDistricts
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.BOUNDARIES.AssociationOfGovernments
2 issues found:
    missing tags: ['SGID', 'Boundaries']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.BLM_RMPTargetedLands
2 issues found:
    missing tags: ['SGID', 'Cadastre']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.Parcels_BoxElder_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.GSLMeanderLine
2 issues found:
    missing tags: ['SGID', 'Cadastre']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Beaver_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.LandOwnership
2 issues found:
    missing tags: ['SGID', 'Cadastre']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Beaver
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_BoxElder
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Cache
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Cache_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Carbon
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Carbon_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Daggett
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Daggett_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Davis
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Davis_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Duchesne
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Duchesne_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Emery
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Garfield
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Garfield_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Grand
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Grand_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Iron
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Iron_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Juab
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Juab_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Kane
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Kane_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Millard
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Millard_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Morgan
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Morgan_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Piute
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Rich
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Rich_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_SaltLake
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_SaltLake_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_SanJuan
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_SanJuan_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Sanpete
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Sanpete_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Sevier
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Sevier_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Summit
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Summit_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Tooele
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Tooele_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Uintah
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Utah
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Utah_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Wasatch
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Wasatch_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Washington
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Washington_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Wayne
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Wayne_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Weber
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.Parcels_Weber_LIR
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: parcels (should be: Parcels)
    Summary is longer than 2048 characters.
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSS_EditTracker
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSSPoint_GCDB
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSSQuarterQuarterSections_GCDB
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: quarter quarters (should be: Quarter Quarters)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSSQuarterSections_GCDB
4 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSSSections_GCDB
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.PLSSTownships_GCDB
6 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    incorrectly cased tag: Township and Range. (should be: Township And Range)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.CADASTRE.TURN_GPS_BaseLines
2 issues found:
    missing tags: ['SGID', 'Cadastre']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.TURN_GPS_Stations
2 issues found:
    missing tags: ['SGID', 'Cadastre']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CLIMATE.WeatherStations
2 issues found:
    missing tags: ['SGID', 'Climate']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CLIMATE.NWSForecastZones
2 issues found:
    missing tags: ['SGID', 'Climate']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.UnIncorpAreas2010_Approx
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.UrbanAreasCensus2010
8 issues found:
    missing tags: {'SGID', 'Demographic'}
    incorrectly cased tag: Urban areas (should be: Urban Areas)
    incorrectly cased tag: urban clusters (should be: Urban Clusters)
    incorrectly cased tag: census (should be: Census)
    incorrectly cased tag: urban (should be: Urban)
    incorrectly cased tag: rural (should be: Rural)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.PopPlacePts2010_Approx
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.PopBlockAreas2010_Approx
7 issues found:
    missing tags: {'SGID', 'Demographic'}
    incorrectly cased tag: demographic (should be: Demographic)
    incorrectly cased tag: developed (should be: Developed)
    incorrectly cased tag: buildings (should be: Buildings)
    incorrectly cased tag: populated (should be: Populated)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.MetroMicroStatisticalAreas
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.UnPopUtah_Approx
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusTracts2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusPlaces2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusPlacePoints2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusEdges2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusCounties2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusBlocks2010
8 issues found:
    missing tags: {'SGID'}
    incorrectly cased tag: GOVERNMENTALUNITS (should be: Governmentalunits)
    incorrectly cased tag: tracts (should be: Tracts)
    incorrectly cased tag: census (should be: Census)
    incorrectly cased tag: demographic (should be: Demographic)
    incorrectly cased tag: population (should be: Population)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.DEMOGRAPHIC.CensusBlockGroups2010
2 issues found:
    missing tags: ['SGID', 'Demographic']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ECONOMY.UtahEntities_NonTax
14 issues found:
    missing tags: {'SGID', 'Economy'}
    incorrectly cased tag: usao (should be: USAO)
    incorrectly cased tag: sao (should be: SAO)
    incorrectly cased tag: osa (should be: Osa)
    incorrectly cased tag: utsc (should be: Utsc)
    incorrectly cased tag: fee areas (should be: Fee Areas)
    incorrectly cased tag: development (should be: Development)
    incorrectly cased tag: redevelopment (should be: Redevelopment)
    incorrectly cased tag: conservation (should be: Conservation)
    incorrectly cased tag: special service (should be: Special Service)
    incorrectly cased tag: local (should be: Local)
    incorrectly cased tag: district (should be: District)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ECONOMY.TransitSpecialTaxAreas
6 issues found:
    missing tags: {'SGID', 'Economy'}
    incorrectly cased tag: Transit Special Tax areas (should be: Transit Special Tax Areas)
    incorrectly cased tag: Transit Tax areas (should be: Transit Tax Areas)
    incorrectly cased tag: Special Tax areas (should be: Special Tax Areas)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.ECONOMY.TaxEntities2018
9 issues found:
    missing tags: {'SGID', 'Economy'}
    incorrectly cased tag: tax entity (should be: Tax Entity)
    incorrectly cased tag: ustc (should be: USTC)
    incorrectly cased tag: special service (should be: Special Service)
    incorrectly cased tag: district (should be: District)
    incorrectly cased tag: redevelopment (should be: Redevelopment)
    incorrectly cased tag: miscellaneous (should be: Miscellaneous)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.ECONOMY.TaxAreas2018
11 issues found:
    missing tags: {'SGID', 'Economy'}
    incorrectly cased tag: tax (should be: Tax)
    incorrectly cased tag: tax area (should be: Tax Area)
    incorrectly cased tag: ustc (should be: USTC)
    incorrectly cased tag: special service (should be: Special Service)
    incorrectly cased tag: district (should be: District)
    incorrectly cased tag: redevelopment (should be: Redevelopment)
    incorrectly cased tag: property tax (should be: Property Tax)
    incorrectly cased tag: tax commission (should be: Tax Commission)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.ECONOMY.SalesTaxAreas
3 issues found:
    missing tags: {'SGID', 'Economy'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.ECONOMY.EnterpriseZones
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.ELEVATION.USGS3DEP1KGrid
2 issues found:
    missing tags: ['SGID', 'Elevation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ELEVATION.HighestPeaks
2 issues found:
    missing tags: ['SGID', 'Elevation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ELEVATION.ContoursGeneralized200Ft
5 issues found:
    missing tags: {'SGID', 'Elevation'}
    incorrectly cased tag: contours (should be: Contours)
    incorrectly cased tag: elevation (should be: Elevation)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ELEVATION.Contours500Ft
2 issues found:
    missing tags: ['SGID', 'Elevation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ELEVATION.AvalancheRose_TriCanyons
2 issues found:
    missing tags: ['SGID', 'Elevation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.CoalDepositAreas1988
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.Coal_4FootSeams
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.CoalLeases
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.CoalMines_UGS
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.DNROilGasFields
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.EnergyCorridorAreas
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.EnergyCorridorCenterline
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.EnergyResourcesLine
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.EnergyResourcesPoint
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.EnergyResourcesPoly
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.GeothermalLeases_Utah
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.OilGasWells
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.OilGasWells_DownHoles
13 issues found:
    missing tags: {'SGID', 'Energy'}
    incorrectly cased tag: oil (should be: Oil)
    incorrectly cased tag: gas (should be: Gas)
    incorrectly cased tag: well (should be: Well)
    incorrectly cased tag: mining (should be: Mining)
    incorrectly cased tag: natural resources (should be: Natural Resources)
    incorrectly cased tag: lease (should be: Lease)
    incorrectly cased tag: extraction (should be: Extraction)
    incorrectly cased tag: bottom (should be: Bottom)
    incorrectly cased tag: hole (should be: Hole)
    incorrectly cased tag: horizontal (should be: Horizontal)
    incorrectly cased tag: drilling (should be: Drilling)
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.OilGasWells_Paths
15 issues found:
    missing tags: {'SGID', 'Energy'}
    incorrectly cased tag: oil (should be: Oil)
    incorrectly cased tag: gas (should be: Gas)
    incorrectly cased tag: well (should be: Well)
    incorrectly cased tag: mining (should be: Mining)
    incorrectly cased tag: natural resources (should be: Natural Resources)
    incorrectly cased tag: lease (should be: Lease)
    incorrectly cased tag: extraction (should be: Extraction)
    incorrectly cased tag: bottom (should be: Bottom)
    incorrectly cased tag: hole (should be: Hole)
    incorrectly cased tag: horizontal (should be: Horizontal)
    incorrectly cased tag: drilling (should be: Drilling)
    incorrectly cased tag: path (should be: Path)
    Summary is longer than Description!
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.PermittedUraniumMines
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.PowerPlants_CO2
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.TarSands
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UraniumAreaBoundaries
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UraniumDistricts_UGS
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UraniumMills
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UraniumPastProducers
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase1_GeothermalZones
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase1_SolarZones
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase1_Transmission
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase1_WindDrainage
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase1_WindZones
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase2_ConceptualTransmission
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase2_Geothermal
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENERGY.UREZPhase2_ZoneBoundaries
2 issues found:
    missing tags: ['SGID', 'Energy']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQAirEmissionsInventory
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.BFNONTARGETED
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQAirMonitorByStation
5 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Air monitoring stations (should be: Air Monitoring Stations)
    incorrectly cased tag: air quality (should be: Air Quality)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.BFTARGETED
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQAirOilGasEmissions
5 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Industrial emissions (should be: Industrial Emissions)
    incorrectly cased tag: polution (should be: Polution)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQAirOilGasEmissionsPt
6 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: emissions (should be: Emissions)
    incorrectly cased tag: oil and gas emissions (should be: Oil And Gas Emissions)
    incorrectly cased tag: gas compressor emissions (should be: Gas Compressor Emissions)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQPermitCompApproval
4 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: permit approval (should be: Permit Approval)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQPermitCompTitleV
6 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Clean air act (should be: Clean Air Act)
    incorrectly cased tag: title V (should be: Title V)
    incorrectly cased tag: permits (should be: Permits)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DAQPre1978LeadInHomes
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWMRCHazWasteUsedOilFacilities
3 issues found:
    missing tags: ['SGID', 'Environment']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWMRCLLRWUMillFacilities
3 issues found:
    missing tags: ['SGID', 'Environment']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWMRCSolidWasteFacilities
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQAssessedLakes
4 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Assessed waters (should be: Assessed Waters)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQAssessedWaters
4 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Water quality assessment (should be: Water Quality Assessment)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQAssessmentUnits
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQGroundwaterPermits
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQMercuryInFishTissue
3 issues found:
    missing tags: ['SGID', 'Environment']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQMonitoringLocations
5 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: water (should be: Water)
    incorrectly cased tag: monitoring (should be: Monitoring)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQStormWaterDischargers
6 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: water (should be: Water)
    incorrectly cased tag: water quality (should be: Water Quality)
    incorrectly cased tag: discharge (should be: Discharge)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.DWQUPDESDischargers
6 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: water (should be: Water)
    incorrectly cased tag: water quality (should be: Water Quality)
    incorrectly cased tag: discharge (should be: Discharge)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.EnvironmentalIncidents
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.FacilityMonitoringSites
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.ICBUFFERZONES
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.LakeMonitoring
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.LakeMonitorSites
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.StreamMonitorSites
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.FACILITYUST
4 issues found:
    missing tags: {'SGID', 'Environment'}
    incorrectly cased tag: Underground storage tanks (should be: Underground Storage Tanks)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.UICFacility
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.UPDESSites
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.SITEREM
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.UICWell
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.MMRP
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.TIER2
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.EWA
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.FUD
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.NPL
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.VCP
3 issues found:
    missing tags: {'SGID', 'Environment'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.TRI
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.FARMING.GrazingImprovementRegions
2 issues found:
    missing tags: ['SGID', 'Farming']
    Use limitations text is missing.
---
Metadata Test Report for SGID.FARMING.GrazingAllotments
2 issues found:
    missing tags: ['SGID', 'Farming']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.PhysiographicSubdivisions
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.QuaternaryVolcanicVents
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LandslideInventoryPolygons
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LandslideInventoryMappedAreas
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.QuaternaryVolcanicFlow
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LandslideCompilationScarps
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LandslideCompilationPolygons
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LandslideCompilationDebrisFlowPaths
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.GeologicFormationsLine
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.LiquefactionPotential
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.ShallowGroundWater
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.GeologicContacts
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.QuaternaryFaults
4 issues found:
    missing tags: {'SGID', 'Geoscience'}
    incorrectly cased tag: GeoscientificInformation (should be: Geoscientificinformation)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.GEOSCIENCE.GeologicMarkers
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.EarthquakeEpicentersMiningInduced_1928to2016
2 issues found:
    missing tags: {'SGID', 'Geoscience'}
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.EarthquakeEpicenters_1850to2016
2 issues found:
    missing tags: {'SGID', 'Geoscience'}
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.DebrisFlow_WasatchStudyBoundary
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.DebrisFlow_WasatchFront
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.VolcanicCones
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.GeologicDikes
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.AvalanchePaths
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.GeologicVeins
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.Aquifer_RechargeDischargeAreas
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.Aquifer_BasinFillBoundary
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.GEOSCIENCE.AlluvialFans
6 issues found:
    missing tags: {'SGID', 'Geoscience'}
    incorrectly cased tag: geoscience (should be: Geoscience)
    incorrectly cased tag: alluvial (should be: Alluvial)
    incorrectly cased tag: fans (should be: Fans)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.GEOSCIENCE.Minerals
2 issues found:
    missing tags: ['SGID', 'Geoscience']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.HealthSmallStatisticalAreas2018
6 issues found:
    missing tags: {'SGID', 'Health'}
    incorrectly cased tag: health (should be: Health)
    incorrectly cased tag: small areas (should be: Small Areas)
    incorrectly cased tag: statistics (should be: Statistics)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.HealthSmallStatisticalAreas2017
3 issues found:
    missing tags: {'SGID', 'Health'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.HEALTH.HealthCareFacilities
2 issues found:
    missing tags: ['SGID', 'Health']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.EMSFacilities
2 issues found:
    missing tags: ['SGID', 'Health']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.EmergencyMedicalServices
2 issues found:
    missing tags: ['SGID', 'Health']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HISTORY.HistoricDistricts
2 issues found:
    missing tags: ['SGID', 'History']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HISTORY.HistoricTrails
2 issues found:
    missing tags: ['SGID', 'History']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.Google_UtahServiceDates
3 issues found:
    missing tags: ['SGID', 'Indices']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS24KQuarterQuads
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS_DEM_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS250KQuads1x1
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS250KQuads1x2
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.Google_FlightBlocks
3 issues found:
    missing tags: ['SGID', 'Indices']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS100KQuads
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.USGS24KQuads
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.LiDAR_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.NationalGrid
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.Contour_Line_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.DRG_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.AutoCorrelated_DEM_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.Aerial_Photography_Extents
2 issues found:
    missing tags: ['SGID', 'Indices']
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.LUCABlockAddressCounts2017
5 issues found:
    missing tags: {'SGID', 'Location'}
    incorrectly cased tag: census blocks (should be: Census Blocks)
    incorrectly cased tag: address points (should be: Address Points)
    Summary is longer than Description!
    Use limitations text is not standard.
---
Metadata Test Report for SGID.LOCATION.CitiesTownsLocations
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.PlaceNamesGNIS
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.LOCATION.AddressSystemQuadrants
3 issues found:
    missing tags: {'SGID', 'Location'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.LOCATION.HexagonGrid_1km
3 issues found:
    missing tags: {'SGID', 'Location'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.ZipCodePOBoxes
2 issues found:
    missing tags: ['SGID', 'Location']
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.ZoomLocations
2 issues found:
    missing tags: ['SGID', 'Location']
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.AddressPoints
2 issues found:
    missing tags: ['SGID', 'Location']
    Use limitations text is missing.
---
Metadata Test Report for SGID.LOCATION.Buildings
7 issues found:
    missing tags: {'SGID', 'Location'}
    incorrectly cased tag: buildings (should be: Buildings)
    incorrectly cased tag: building footprints (should be: Building Footprints)
    incorrectly cased tag: building outlines (should be: Building Outlines)
    incorrectly cased tag: structure (should be: Structure)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_WashingtonCo
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_WDesert1999
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.UtahPLI_Lines_Proposal_Jan16
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_NineCo1995
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.UtahPLI_Areas_Proposal_Jan16
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.UWC2008CherryStemRoads
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_UWA1995
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_UWC1989
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_UWC1995
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_UWC2008
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.PublicLandsInitiativeHR5780Areas_BLM2016
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.PublicLandsInitiativeHR5780Lines_BLM2016
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.SemiPrimitiveProp_EmeryCo
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.UrbanInterfaceAreas
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WaterRelatedLandUse
22 issues found:
    missing tags: {'Planning', 'SGID'}
    incorrectly cased tag: land (should be: Land)
    incorrectly cased tag: use (should be: Use)
    incorrectly cased tag: landuse (should be: Landuse)
    incorrectly cased tag: agriculture (should be: Agriculture)
    incorrectly cased tag: water (should be: Water)
    incorrectly cased tag: resources (should be: Resources)
    incorrectly cased tag: water resources (should be: Water Resources)
    incorrectly cased tag: related (should be: Related)
    incorrectly cased tag: water-related (should be: Water-Related)
    incorrectly cased tag: inventory (should be: Inventory)
    incorrectly cased tag: dwre (should be: Dwre)
    incorrectly cased tag: dnr (should be: Dnr)
    incorrectly cased tag: wre (should be: Wre)
    incorrectly cased tag: current (should be: Current)
    incorrectly cased tag: data (should be: Data)
    incorrectly cased tag: ag (should be: Ag)
    incorrectly cased tag: polygons (should be: Polygons)
    incorrectly cased tag: boundary (should be: Boundary)
    incorrectly cased tag: cropland (should be: Cropland)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_BLM
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_HR1500
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_HR1745
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.WildernessProp_RedRock
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.GSENM_SpecRecManArea
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.NCAProp_SanJuanCo
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.PrimitiveProp_EmeryCo
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.PLANNING.GSENM_SpecManArea
2 issues found:
    missing tags: ['SGID', 'Planning']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahSchoolBoardDistricts2015
4 issues found:
    missing tags: {'SGID'}
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.VistaBallotAreas_Proposed
3 issues found:
    missing tags: {'SGID', 'Political'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.USCongressDistricts2012
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahHouseDistricts2002
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahHouseDistricts2012
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahSenateDistricts2002
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahSenateDistricts2012
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.USCongressDistricts2002
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.VistaBallotAreas
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UniqueHouseSenate2002
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.JudicialDistricts
2 issues found:
    missing tags: ['SGID', 'Political']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.SkiAreaBoundaries
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.SkiAreaLocations
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.GolfCourses
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.SkiTrails_XC
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.BoatRamps
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.ParksLocal
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.SkiLifts
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.Trailheads
2 issues found:
    missing tags: ['SGID', 'Recreation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.RECREATION.Trails
6 issues found:
    missing tags: {'Recreation', 'SGID'}
    incorrectly cased tag: biking (should be: Biking)
    incorrectly cased tag: atv (should be: Atv)
    incorrectly cased tag: hiking (should be: Hiking)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.UHPFieldSections
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.StateAgencyDispatch
4 issues found:
    missing tags: {'SGID', 'Society'}
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.StateCourtDistricts
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.StateFacilities
2 issues found:
    missing tags: ['SGID', 'Society']
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.PSAPBoundaries
4 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: e911 (should be: E911)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.PSAPLocations
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.Schools
2 issues found:
    missing tags: ['SGID', 'Society']
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.Libraries
4 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: Utah. (should be: Utah)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.LiquorStores
2 issues found:
    missing tags: ['SGID', 'Society']
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.PostOffices
3 issues found:
    missing tags: ['SGID', 'Society']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.LawEnforcementBoundaries
6 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: law enforcemtent (should be: Law Enforcemtent)
    incorrectly cased tag: police  department (should be: Police Department)
    incorrectly cased tag: sheriffs office (should be: Sheriffs Office)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.LawEnforcement
21 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: Airport police (should be: Airport Police)
    incorrectly cased tag: Border patrols (should be: Border Patrols)
    incorrectly cased tag: Community policing (should be: Community Policing)
    incorrectly cased tag: Drug enforcement agents (should be: Drug Enforcement Agents)
    incorrectly cased tag: Indian reservation police (should be: Indian Reservation Police)
    incorrectly cased tag: Juvenile detention homes (should be: Juvenile Detention Homes)
    incorrectly cased tag: Law enforcement (should be: Law Enforcement)
    incorrectly cased tag: Military police (should be: Military Police)
    incorrectly cased tag: Police stations (should be: Police Stations)
    incorrectly cased tag: Police training (should be: Police Training)
    incorrectly cased tag: School police (should be: School Police)
    incorrectly cased tag: Secret service (should be: Secret Service)
    incorrectly cased tag: Transit police (should be: Transit Police)
    incorrectly cased tag: United States. Bureau of Alcohol (should be: United States Bureau of Alcohol)
    incorrectly cased tag: and Firearms (should be: And Firearms)
    incorrectly cased tag: United States. Federal Bureau of Investigation (should be: United States Federal Bureau of Investigation)
    incorrectly cased tag: United States marshals (should be: United States Marshals)
    incorrectly cased tag: structure (should be: Structure)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.ForestServiceStations
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.FireStations
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.Courts_County
4 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: County Courts In Utah (should be: County Courts in Utah)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.Courts_City
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.CorrectionalFacilities
3 issues found:
    missing tags: ['SGID', 'Society']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.Cemeteries_Poly
3 issues found:
    missing tags: {'SGID', 'Society'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.SOCIETY.Cemeteries
2 issues found:
    missing tags: ['SGID', 'Society']
    Use limitations text is missing.
---
Metadata Test Report for SGID.SOCIETY.BLMFieldOffices
4 issues found:
    missing tags: {'SGID', 'Society'}
    incorrectly cased tag: structure (should be: Structure)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.TRANSPORTATION.UDOTMap_ScenicByways
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.UDOTTenthMileRefPoints
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.LightRailStations_UTA
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.CommuterRailStations_UTA
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.Roads_FreewayExits
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.TRANSPORTATION.Railroad_Mileposts
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.CommuterRailRoutes_UTA
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.UDOTRoutes_LRS
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.UDOTMileposts
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.LightRail_UTA
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.PortsOfEntry
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.BusFlexRoutes_UTA
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.Railroads
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.Airports
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.AirportLocations
2 issues found:
    missing tags: ['SGID', 'Transportation']
    Use limitations text is missing.
---
Metadata Test Report for SGID.UTILITIES.TransmissionLines
2 issues found:
    missing tags: ['SGID', 'Utilities']
    Use limitations text is missing.
---
Metadata Test Report for SGID.UTILITIES.RetailCulinaryWaterServiceAreas
26 issues found:
    missing tags: {'SGID', 'Utilities'}
    incorrectly cased tag: water (should be: Water)
    incorrectly cased tag: culinary (should be: Culinary)
    incorrectly cased tag: culinary water (should be: Culinary Water)
    incorrectly cased tag: potable (should be: Potable)
    incorrectly cased tag: potable water (should be: Potable Water)
    incorrectly cased tag: water systems (should be: Water Systems)
    incorrectly cased tag: water suppliers (should be: Water Suppliers)
    incorrectly cased tag: culinary water suppliers (should be: Culinary Water Suppliers)
    incorrectly cased tag: public culinary water suppliers (should be: Public Culinary Water Suppliers)
    incorrectly cased tag: potable water suppliers (should be: Potable Water Suppliers)
    incorrectly cased tag: potable water systems (should be: Potable Water Systems)
    incorrectly cased tag: public water suppliers (should be: Public Water Suppliers)
    incorrectly cased tag: public water systems (should be: Public Water Systems)
    incorrectly cased tag: retail culinary system boundaries (should be: Retail Culinary System Boundaries)
    incorrectly cased tag: municipal (should be: Municipal)
    incorrectly cased tag: municipal water (should be: Municipal Water)
    incorrectly cased tag: industrial (should be: Industrial)
    incorrectly cased tag: industrial water (should be: Industrial Water)
    incorrectly cased tag: water use (should be: Water Use)
    incorrectly cased tag: culinary water use (should be: Culinary Water Use)
    incorrectly cased tag: potable water use (should be: Potable Water Use)
    incorrectly cased tag: public community water systems (should be: Public Community Water Systems)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.UTILITIES.NaturalGasService_Approx
6 issues found:
    missing tags: {'SGID', 'Utilities'}
    incorrectly cased tag: Natural gas (should be: Natural Gas)
    incorrectly cased tag: service areas (should be: Service Areas)
    incorrectly cased tag: utilities (should be: Utilities)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.UTILITIES.ElectricalService
3 issues found:
    missing tags: {'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.UTILITIES.ElectricalLines
2 issues found:
    missing tags: ['SGID', 'Utilities']
    Use limitations text is missing.
---
Metadata Test Report for SGID.UTILITIES.BroadbandService
11 issues found:
    missing tags: {'SGID', 'Utilities'}
    incorrectly cased tag: internet (should be: Internet)
    incorrectly cased tag: utilities (should be: Utilities)
    incorrectly cased tag: digital (should be: Digital)
    incorrectly cased tag: mobile (should be: Mobile)
    incorrectly cased tag: cell (should be: Cell)
    incorrectly cased tag: fiber (should be: Fiber)
    incorrectly cased tag: dsl (should be: Dsl)
    incorrectly cased tag: cable (should be: Cable)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.WetlandsMappingProjects
4 issues found:
    missing tags: {'SGID'}
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.WATER.StreamsNHDHighRes
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.UtahMajorRiversPoly
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.LakesNHDHighRes
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.NHDHighRes_PointsAll
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.SpringsNHDHighRes
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.StreamGaugesNHD
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.UtahMajorLakes
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.Watersheds_Area
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.Wetlands
14 issues found:
    missing tags: {'SGID', 'Water'}
    incorrectly cased tag: environment (should be: Environment)
    incorrectly cased tag: oceans (should be: Oceans)
    incorrectly cased tag: Deepwater habitats (should be: Deepwater Habitats)
    incorrectly cased tag: Coastal waters (should be: Coastal Waters)
    incorrectly cased tag: geoscientificInformation (should be: Geoscientificinformation)
    incorrectly cased tag: marshes (should be: Marshes)
    incorrectly cased tag: bogs (should be: Bogs)
    incorrectly cased tag: fens (should be: Fens)
    incorrectly cased tag: Surface water (should be: Surface Water)
    incorrectly cased tag: U.S. Fish and Wildlife Service (should be: US Fish And Wildlife Service)
    incorrectly cased tag: inlandWaters (should be: Inlandwaters)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.WATER.GSLFlooding
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.GSLShoreline
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.GSLShorelineFlooding
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.HistoricLakeBonneville
5 issues found:
    missing tags: {'SGID', 'Water'}
    incorrectly cased tag: boundaries (should be: Boundaries)
    incorrectly cased tag: environment (should be: Environment)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.WATER.HUC
7 issues found:
    missing tags: {'SGID', 'Water'}
    incorrectly cased tag: Sub-region (should be: Sub-Region)
    incorrectly cased tag: Sub-basin (should be: Sub-Basin)
    incorrectly cased tag: boundaries (should be: Boundaries)
    incorrectly cased tag: WBD (should be: Wbd)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.WATER.Stations
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.DDWIrrigatedCropConsumptiveUseZones
5 issues found:
    missing tags: {'SGID', 'Water'}
    incorrectly cased tag: crops (should be: Crops)
    incorrectly cased tag: drinking water (should be: Drinking Water)
    Summary is longer than Description!
    Use limitations text is missing.
---
Metadata Test Report for SGID.WATER.Floodplains
2 issues found:
    missing tags: ['SGID', 'Water']
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.SmallAreas_ObesityAndActivity
6 issues found:
    missing tags: {'SGID', 'Health'}
    incorrectly cased tag: small areas (should be: Small Areas)
    incorrectly cased tag: physical activity (should be: Physical Activity)
    incorrectly cased tag: obesity (should be: Obesity)
    Summary is longer than Description!
    Use limitations text is missing.
---
Metadata Test Report for SGID.UTILITIES.RuralTelcomBoundaries
3 issues found:
    missing tags: {'SGID', 'Utilities'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.DistrictCombinationAreas2012
4 issues found:
    missing tags: ['SGID', 'Political']
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.POLITICAL.UtahSchoolBoardDistricts2012
4 issues found:
    missing tags: {'SGID'}
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.ENVIRONMENT.Total_IC_and_ReservationTribalLand
2 issues found:
    missing tags: ['SGID', 'Environment']
    Use limitations text is missing.
---
Metadata Test Report for SGID.CADASTRE.PLSSPoint_AGRC
5 issues found:
    missing tags: {'SGID', 'Cadastre'}
    incorrectly cased tag: planningCadastre (should be: Planningcadastre)
    Summary is longer than Description!
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.TRANSPORTATION.Roads
6 issues found:
    missing tags: {'SGID'}
    incorrectly cased tag: DOT (should be: Dot)
    incorrectly cased tag: All Roads Network Of Linear-Referenced Data (should be: All Roads Network of Linear-Referenced Data)
    incorrectly cased tag: ARNOLD (should be: Arnold)
    Description is missing link to gis.utah.gov data page.
    Use limitations text is not standard.
---
Metadata Test Report for SGID.TRANSPORTATION.BusRoutes_UTA
3 issues found:
    missing tags: {'Transportation', 'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.TRANSPORTATION.BusStops_UTA
3 issues found:
    missing tags: {'Transportation', 'SGID'}
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.INDICES.Hexagon_ServiceDates
3 issues found:
    missing tags: ['SGID', 'Indices']
    Description is missing link to gis.utah.gov data page.
    Use limitations text is missing.
---
Metadata Test Report for SGID.HEALTH.HealthDistricts
2 issues found:
    missing tags: ['SGID', 'Health']
    Use limitations text is missing.
---
```
