### PR TITLE
fix: http -> https

### DIFF
--- a/src/sweeper/sweepers/UseLimitations.html
+++ b/src/sweeper/sweepers/UseLimitations.html
@@ -3,8 +3,8 @@
 </p>
 
 <p>
-    <a href="http://creativecommons.org/licenses/by/4.0/" rel="license nofollow noopener ugc">
+    <a href="https://creativecommons.org/licenses/by/4.0/" rel="license nofollow noopener ugc">
         <img alt="Creative Commons License" src="https://i.creativecommons.org/l/by/4.0/88x31.png" rel="license nofollow noopener ugc" style="border-width:0;" />
     </a>
-    <br />This work is licensed under a <a href="http://creativecommons.org/licenses/by/4.0/" rel="license nofollow noopener ugc">Creative Commons Attribution 4.0 International License</a>.
+    <br />This work is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/" rel="license nofollow noopener ugc">Creative Commons Attribution 4.0 International License</a>.
 </p>


### PR DESCRIPTION
I noticed this when attempting to copy and paste this into an AGOL item using the website UI. It popped an error message about http.