### PR TITLE
ci: create a pypi release when tagged

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,5 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+[*.yml]
+indent_size = 2

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,0 +1,32 @@
+name: Publish on tag
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Set up code
+        uses: actions/checkout@v3
+
+      - name: 🐍 Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+
+      - name: 👊 Bump version
+        run: |
+          TAG=$(gh release view --json tagName --jq ".tagName")
+          sed "s/version=.*$/version=\"$TAG\",/" setup.py
+
+      - name: 📦 Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: 🚀 Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(*names, **kwargs):
 
 setup(
     name="agrc-sweeper",
-    version="1.2.2",
+    version="0.0.0",
     license="MIT",
     description="CLI tool for making good data",
     long_description="",


### PR DESCRIPTION
## What

This follows the steps in the readme for distribution mostly. I'm assuming the twine stuff is taken care of in the publish action.  I was able to build without arcpy on my mac but the `bdist_wheel` option was invalid until I installed wheel. I guess we'll find out what happens on the ubuntu runner.