### PR TITLE
feat: raise NotImplementedError for invalids

### DIFF
--- a/src/sweeper/__main__.py
+++ b/src/sweeper/__main__.py
@@ -66,7 +66,7 @@ def main():
     if args['duplicates']:
         closet.append(DuplicateTest(args['--workspace'], args['--table-name']))
     elif args['invalids']:
-        pass
+        raise NotImplementedError('"Invalids" sweep/check not implemented yet.')
     elif args['empties']:
         closet.append(EmptyTest(args['--workspace'], args['--table-name']))
     elif args['addresses']:


### PR DESCRIPTION
It's not clear from the usage screen that the invalids sweep is just `pass`ing. This just raises an error to notify the user.