### PR TITLE
chore: fix dep, add h3 to license list, bump version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -99,27 +99,26 @@ A normalized string representing the entire address that was passed into the con
 
 ## Installation (requires Pro 2.7+)
 
-1. create conda environment
-    - `conda create --name sweeper python=3.7`
+<!-- Current conda install arcpy -c esri seems to be wonky; just clone to be safe -->
+1. clone arcgis conda environment
+    - `conda create -name sweeper --clone arcgispro-py3`
 1. activate environment
     - `activate sweeper`
-1. install arcpy
-    - `conda install arcpy -c esri`
 1. install sweeper
     - `pip install agrc-sweeper`
 
 ## Development
 
-1. create conda environment
-    - `conda create --name sweeper python=3.7`
+1. clone arcgis conda environment
+    - `conda create -name sweeper --clone arcgispro-py3`
 1. activate environment
     - `activate sweeper`
 1. `test_metadata.py` uses a SQL database that needs to be restored via `src/sweeper/tests/data/Sweeper.bak` to your local SQL Server.
 
 ### Installing dependencies
 
-1. install arcpy
-    - `conda install -c esri arcpy`
+1. clone arcgis conda environment
+    - `conda create -name sweeper --clone arcgispro-py3`
 1. install only required dependencies to run sweeper
     - `pip install -e .`
 1. install required dependencies to work on sweeper

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(*names, **kwargs):
 
 setup(
     name="agrc-sweeper",
-    version="1.1.0",
+    version="0.0.0",
     license="MIT",
     description="CLI tool for making good data",
     long_description="",

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,22 @@ setup(
         "Topic :: Utilities",
     ],
     keywords=[],
-    install_requires=['docopt==0.6.*', 'xxhash >= 3.*', 'agrc-usaddress==0.6.*', 'beautifulsoup4==4.8.*', 'agrc-supervisor==3.*'],
+    install_requires=[
+        'docopt==0.6.*',
+        'xxhash >= 3.*',
+        'agrc-usaddress==0.6.*',
+        'beautifulsoup4==4.8.*',
+        'agrc-supervisor==3.*',
+    ],
     dependency_links=[],
     extras_require={
         'tests': [
             'pytest',
         ],
-        'develop': ['yapf', 'pylint']
+        'develop': [
+            'yapf',
+            'pylint',
+        ]
     },
     entry_points={"console_scripts": ["sweeper = sweeper.__main__:main"]}
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(*names, **kwargs):
 
 setup(
     name="agrc-sweeper",
-    version="0.0.0",
+    version="1.1.0",
     license="MIT",
     description="CLI tool for making good data",
     long_description="",
@@ -36,22 +36,13 @@ setup(
         "Topic :: Utilities",
     ],
     keywords=[],
-    install_requires=[
-        'docopt==0.6.*',
-        'xxhash==1.4.*',
-        'agrc-usaddress==0.6.*',
-        'beautifulsoup4==4.8.*',
-        'agrc-supervisor==1.2.*'
-    ],
+    install_requires=['docopt==0.6.*', 'xxhash >= 3.*', 'agrc-usaddress==0.6.*', 'beautifulsoup4==4.8.*', 'agrc-supervisor==3.*'],
     dependency_links=[],
     extras_require={
         'tests': [
             'pytest',
         ],
-        'develop': [
-            'yapf',
-            'pylint'
-        ]
+        'develop': ['yapf', 'pylint']
     },
     entry_points={"console_scripts": ["sweeper = sweeper.__main__:main"]}
 )

--- a/src/sweeper/__main__.py
+++ b/src/sweeper/__main__.py
@@ -52,8 +52,8 @@ def main():
 
     if args['--scheduled']:
         #: set up supervisor, add email handler
-        sweeper_supervisor = Supervisor(project_name='agrc-sweeper')
-        sweeper_supervisor.add_message_handler(EmailHandler(credentials.EMAIL_SETTINGS))
+        sweeper_supervisor = Supervisor()
+        sweeper_supervisor.add_message_handler(EmailHandler(credentials.EMAIL_SETTINGS, client_name='agrc-sweeper'))
 
     #: backup input file before quality checks
     if args['--backup-to']:
@@ -164,9 +164,7 @@ def setup_logging(save_report, scheduled):
     logger = logging.getLogger('sweeper')
     logger.setLevel(logging.INFO)
 
-    formatter = logging.Formatter(
-        fmt='%(levelname)-7s %(asctime)s %(module)10s:%(lineno)5s %(message)s', datefmt='%m-%d %H:%M:%S'
-        )
+    formatter = logging.Formatter(fmt='%(levelname)-7s %(asctime)s %(module)10s:%(lineno)5s %(message)s', datefmt='%m-%d %H:%M:%S')
 
     #: always set up console_handler
     console_handler = logging.StreamHandler(stream=sys.stdout)

--- a/src/sweeper/sweepers/metadata.py
+++ b/src/sweeper/sweepers/metadata.py
@@ -28,7 +28,15 @@ ARTICLES = ['a', 'the', 'of', 'is', 'in']
 
 DATA_PAGE_LINK_REGEX = re.compile(r'gis\.utah\.gov.*\/data', re.IGNORECASE)
 
-HAS_OWN_LICENSE = ['opensourceplaces', 'buildings']
+HAS_OWN_LICENSE = [
+    'opensourceplaces',
+    'buildings',
+    'h3_hexes_z5',
+    'h3_hexes_z6',
+    'h3_hexes_z7',
+    'h3_hexes_z8',
+    'h3_hexes_z9',
+    ]
 
 with open(join(dirname(realpath(__file__)), 'UseLimitations.html')) as file:
     STANDARD_LIMITATIONS = re.sub(r'\s\s+', '', file.read()).replace('\n', '')


### PR DESCRIPTION
This adds the h3 layers to the list of layers with their own licenses.

Also bumps xxhash to >= 3.* to fix pip install problems.

It looks like the versioning for agrc-sweeper is handled by a github action? Do I need to tag the PR or latest commit to trigger that?

I also need some help testing to make sure the xxhash version bump doesn't break anything.